### PR TITLE
ci: generic trigger + dynamic APP_VERSION for security-scan

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -3,12 +3,12 @@ name: Security Scan
 on:
   push:
     branches:
-      - test-rs
+      - master
+      - 'cadenzaflow-*.*.*'
   workflow_dispatch:
 
 env:
   APP_NAME: cadenzaflow-bpm-platform
-  APP_VERSION: "test-rs"
   MAIL_TO: ali.aras@pia-team.com,rahmani.saygin@pia-team.com
   SMTP_SERVER: mail-eu.smtp2go.com
   SMTP_PORT: "2525"
@@ -20,6 +20,24 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Resolve APP_VERSION from root pom.xml
+        id: ver
+        run: |
+          VERSION=$(python3 - <<'PY'
+          import xml.etree.ElementTree as ET
+          ns = {'m': 'http://maven.apache.org/POM/4.0.0'}
+          root = ET.parse('pom.xml').getroot()
+          v = root.find('m:version', ns)
+          print(v.text if v is not None else '')
+          PY
+          )
+          if [ -z "$VERSION" ]; then
+            echo "::error::Unable to read project version from pom.xml" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected APP_VERSION: $VERSION"
 
       - name: Trivy filesystem scan
         id: trivy_fs
@@ -36,7 +54,7 @@ jobs:
         uses: ./.github/actions/security-report
         with:
           app_name: ${{ env.APP_NAME }}
-          version: ${{ env.APP_VERSION }}
+          version: ${{ steps.ver.outputs.version }}
           environment: production
           trivy_repo_report: ''
           trivy_fs_report: ${{ steps.trivy_fs.outputs.report_path }}


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `test-rs` push trigger and `APP_VERSION` with generic patterns that survive release branches.
- Trigger: `master` + `cadenzaflow-*.*.*` (matches the v1.2.0+ release pattern).
- APP_VERSION resolved at runtime from root `pom.xml` `<version>` (via a small Python step). Lokal sanity check returns `1.2.0`.

## Why

The workflow has been dormant since 2026-05-07, when `test-rs` was renamed to `cadenzaflow-1.2.0` as part of the v1.2.0 release. No Trivy scan has fired in that period.

Hardcoded version was also the source of recurring `add/add` conflicts during `master --no-ff` merges of release branches, called out in the release-process docs.

## Trigger compatibility with the new release pattern

Per `cadenzaflow-vX.Y.Z` annotated tags + master canonical history (started 2026-05-07):
- Push to `master` → scan with version from POM (currently `1.2.0`)
- Push to any `cadenzaflow-X.Y.Z` release branch → same
- `workflow_dispatch` retained for manual reruns

## Test plan

- [ ] Workflow appears active on the branches above after merge
- [ ] Manual `workflow_dispatch` from the Actions tab succeeds and emails a report addressing version `1.2.0`
- [ ] Next push to `cadenzaflow-1.2.0` triggers a run and resolves the same version
- [ ] No `add/add` conflict on the next `master --no-ff` merge of a release branch (the next release should validate this)

## Out of scope

- The `trivy-scan` / `security-report` composite actions in `.github/actions/` are unchanged.
- SMTP recipients are unchanged (`ali.aras@pia-team.com`, `rahmani.saygin@pia-team.com`).
- Independent of PR #3 (`ci: add push-trigger test workflow`); both can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)