### PR TITLE
build: pin LF for shell scripts via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Line-ending policy for build correctness.
+#
+# The distro assemblies package shell scripts straight from the working tree.
+# On a Windows clone with core.autocrlf=true, .sh files were checked out with
+# CRLF and shipped that way inside the tomcat/run archives — on Linux the
+# scripts then fail (e.g. CATALINA_OPTS="-Xmx512m<CR>" -> "Invalid maximum
+# heap size"). Pin the endings so the checkout is correct on every platform:
+*.sh text eol=lf
+*.bat text eol=crlf
+*.cmd text eol=crlf


### PR DESCRIPTION
The distro assemblies package `.sh` files straight from the working tree. On a Windows clone with `core.autocrlf=true` they are checked out with CRLF and shipped that way inside the tomcat/run archives — on Linux the scripts then break (`setenv.sh`'s `CATALINA_OPTS="-Xmx512m<CR>"` → `Invalid maximum heap size: -Xmx512m`, `run.sh`/`start.sh` bad interpreter).

Found while smoke-testing the published 1.2.0 downloads in a Linux container. The 1.2.0 release assets were rebuilt from an LF-clean checkout and replaced on the `cadenzaflow-v1.2.0` release; this change prevents the same trap for future builds on any clone.

- `*.sh` → LF (required by Linux/macOS)
- `*.bat` / `*.cmd` → CRLF (canonical for Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)