### PR TITLE
fix(spring-boot-4): Spring Security test classpath leak + Boot 4 TestRestTemplate wiring

### DIFF
--- a/spring-boot-starter-4/starter-rest/pom.xml
+++ b/spring-boot-starter-4/starter-rest/pom.xml
@@ -55,6 +55,13 @@
       <artifactId>spring-boot-resttestclient</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- TestRestTemplate builds on RestTemplateBuilder from spring-boot-restclient,
+      which spring-boot-resttestclient does not pull in transitively -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-restclient</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.h2database</groupId>

--- a/spring-boot-starter-4/starter-rest/src/test/java/org/cadenzaflow/bpm/spring/boot/starter/rest/CamundaBpmRestConfigurationIT.java
+++ b/spring-boot-starter-4/starter-rest/src/test/java/org/cadenzaflow/bpm/spring/boot/starter/rest/CamundaBpmRestConfigurationIT.java
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -33,6 +34,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { TestRestApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestRestTemplate
 public class CamundaBpmRestConfigurationIT {
 
   @Autowired

--- a/spring-boot-starter-4/starter-rest/src/test/java/org/cadenzaflow/bpm/spring/boot/starter/rest/SampleCamundaRestApplicationIT.java
+++ b/spring-boot-starter-4/starter-rest/src/test/java/org/cadenzaflow/bpm/spring/boot/starter/rest/SampleCamundaRestApplicationIT.java
@@ -33,6 +33,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -48,6 +49,7 @@ import my.own.custom.spring.boot.project.SampleCamundaRestApplication;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = SampleCamundaRestApplication.class, webEnvironment = RANDOM_PORT)
+@AutoConfigureTestRestTemplate
 public class SampleCamundaRestApplicationIT {
 
   @Autowired

--- a/spring-boot-starter-4/starter-security/pom.xml
+++ b/spring-boot-starter-4/starter-security/pom.xml
@@ -53,6 +53,13 @@
       <artifactId>spring-boot-resttestclient</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- TestRestTemplate builds on RestTemplateBuilder from spring-boot-restclient,
+      which spring-boot-resttestclient does not pull in transitively -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-restclient</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- Spring Boot 4 moved @AutoConfigureMockMvc into spring-boot-webmvc-test -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/spring-boot-starter-4/starter-security/src/test/java/org/cadenzaflow/bpm/spring/boot/starter/security/oauth2/AbstractSpringSecurityIT.java
+++ b/spring-boot-starter-4/starter-security/src/test/java/org/cadenzaflow/bpm/spring/boot/starter/security/oauth2/AbstractSpringSecurityIT.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.beans.BeansException;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.security.core.GrantedAuthority;
@@ -47,6 +48,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = SampleApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestRestTemplate
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public abstract class AbstractSpringSecurityIT {
 

--- a/spring-boot-starter-4/starter-webapp-core/pom.xml
+++ b/spring-boot-starter-4/starter-webapp-core/pom.xml
@@ -60,15 +60,12 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- Spring Boot 4 split autoconfigure: jdbc / security autoconfigure live in their own modules -->
+    <!-- Spring Boot 4 split autoconfigure: jdbc autoconfigure lives in its own module.
+      Do NOT add spring-boot-security here: it drags spring-security-config/web onto the
+      test classpath and Boot's default login page shadows the webapp filters under test. -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-jdbc</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-security</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/spring-boot-starter-4/starter-webapp-core/pom.xml
+++ b/spring-boot-starter-4/starter-webapp-core/pom.xml
@@ -59,6 +59,13 @@
       <artifactId>spring-boot-resttestclient</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- TestRestTemplate builds on RestTemplateBuilder from spring-boot-restclient,
+      which spring-boot-resttestclient does not pull in transitively -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-restclient</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Spring Boot 4 split autoconfigure: jdbc autoconfigure lives in its own module.
       Do NOT add spring-boot-security here: it drags spring-security-config/web onto the

--- a/spring-boot-starter-4/starter-webapp-core/src/test/java/org/cadenzaflow/bpm/spring/boot/starter/webapp/apppath/ChangedAppPathIT.java
+++ b/spring-boot-starter-4/starter-webapp-core/src/test/java/org/cadenzaflow/bpm/spring/boot/starter/webapp/apppath/ChangedAppPathIT.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -44,6 +45,7 @@ import static org.cadenzaflow.bpm.webapp.impl.security.filter.headersec.provider
 @TestPropertySource(properties = {
     "cadenzaflow.bpm.webapp.applicationPath=" + ChangedAppPathIT.MY_APP_PATH
 })
+@AutoConfigureTestRestTemplate
 public class ChangedAppPathIT {
 
   protected static final String MY_APP_PATH = "/my/application/path";

--- a/spring-boot-starter-4/starter-webapp-core/src/test/java/org/cadenzaflow/bpm/spring/boot/starter/webapp/apppath/EmptyAppPathIT.java
+++ b/spring-boot-starter-4/starter-webapp-core/src/test/java/org/cadenzaflow/bpm/spring/boot/starter/webapp/apppath/EmptyAppPathIT.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -37,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestPropertySource(properties = {
     "cadenzaflow.bpm.webapp.applicationPath=" + EmptyAppPathIT.MY_APP_PATH
 })
+@AutoConfigureTestRestTemplate
 public class EmptyAppPathIT {
 
   protected static final String MY_APP_PATH = "";

--- a/spring-boot-starter-4/starter-webapp-core/src/test/java/org/cadenzaflow/bpm/spring/boot/starter/webapp/apppath/containerbasedauth/ChangedAppPathContainerBasedAuthIT.java
+++ b/spring-boot-starter-4/starter-webapp-core/src/test/java/org/cadenzaflow/bpm/spring/boot/starter/webapp/apppath/containerbasedauth/ChangedAppPathContainerBasedAuthIT.java
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
@@ -35,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestPropertySource(properties = {
     "cadenzaflow.bpm.webapp.applicationPath=" + ChangedAppPathContainerBasedAuthIT.MY_APP_PATH
 })
+@AutoConfigureTestRestTemplate
 public class ChangedAppPathContainerBasedAuthIT {
 
   protected static final String MY_APP_PATH = "/my/application/path";

--- a/spring-boot-starter-4/starter-webapp-core/src/test/java/org/cadenzaflow/bpm/spring/boot/starter/webapp/apppath/containerbasedauth/ContainerBasedAuthFilterRegistration.java
+++ b/spring-boot-starter-4/starter-webapp-core/src/test/java/org/cadenzaflow/bpm/spring/boot/starter/webapp/apppath/containerbasedauth/ContainerBasedAuthFilterRegistration.java
@@ -17,16 +17,19 @@
 package org.cadenzaflow.bpm.spring.boot.starter.webapp.apppath.containerbasedauth;
 
 import org.cadenzaflow.bpm.webapp.impl.security.auth.ContainerBasedAuthenticationFilter;
-import org.springframework.boot.security.autoconfigure.web.servlet.SecurityFilterProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 
 import java.util.Collections;
 
 @Configuration
-@Order(SecurityFilterProperties.BASIC_AUTH_ORDER - 15)
+// Same value as Spring Boot's SecurityFilterProperties.BASIC_AUTH_ORDER - 15. Referencing that
+// class would require spring-boot-security on the test classpath, which pulls in Spring Security
+// and its default login page would shadow the webapp filters under test.
+@Order(Ordered.LOWEST_PRECEDENCE - 20)
 public class ContainerBasedAuthFilterRegistration {
 
     @Bean

--- a/spring-boot-starter-4/starter-webapp/pom.xml
+++ b/spring-boot-starter-4/starter-webapp/pom.xml
@@ -31,6 +31,13 @@
       <artifactId>spring-boot-resttestclient</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- TestRestTemplate builds on RestTemplateBuilder from spring-boot-restclient,
+      which spring-boot-resttestclient does not pull in transitively -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-restclient</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.cadenzaflow.bpm.webapp</groupId>

--- a/spring-boot-starter-4/starter-webapp/src/test/java/org/cadenzaflow/bpm/spring/boot/starter/webapp/WebappTest.java
+++ b/spring-boot-starter-4/starter-webapp/src/test/java/org/cadenzaflow/bpm/spring/boot/starter/webapp/WebappTest.java
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -35,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
   classes = WebappExampleApplication.class,
   webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
+@AutoConfigureTestRestTemplate
 public class WebappTest {
 
   @Autowired

--- a/spring-boot-starter-4/starter/pom.xml
+++ b/spring-boot-starter-4/starter/pom.xml
@@ -137,6 +137,13 @@
       <artifactId>spring-boot-resttestclient</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- TestRestTemplate builds on RestTemplateBuilder from spring-boot-restclient,
+      which spring-boot-resttestclient does not pull in transitively -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-restclient</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>com.fasterxml.uuid</groupId>
       <artifactId>java-uuid-generator</artifactId>

--- a/spring-boot-starter-4/starter/src/test/java/org/cadenzaflow/bpm/spring/boot/starter/CamundaBpmActuatorConfigurationIT.java
+++ b/spring-boot-starter-4/starter/src/test/java/org/cadenzaflow/bpm/spring/boot/starter/CamundaBpmActuatorConfigurationIT.java
@@ -24,11 +24,13 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { TestApplication.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestRestTemplate
 public class CamundaBpmActuatorConfigurationIT extends AbstractCamundaAutoConfigurationIT{
 
   @Autowired

--- a/spring-boot-starter-4/starter/src/test/resources/application-default.properties
+++ b/spring-boot-starter-4/starter/src/test/resources/application-default.properties
@@ -3,4 +3,4 @@ cadenzaflow.bpm.database.schema-update=true
 cadenzaflow.bpm.history-level=auto
 
 management.endpoint.health.show-details=always
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+spring.autoconfigure.exclude=org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration


### PR DESCRIPTION
## Problem

CI run 28872774856 (test.yml) reported 4 failures in `spring-boot-starter-4/starter-webapp-core`, all in `org.cadenzaflow.bpm.spring.boot.starter.webapp.filter.redirect`:

- `ResourceLoadingProcessEnginesAppPathCamundaIndexRedirectTest.shouldRedirectRequestToTasklist_contextRoot`
- `ResourceLoadingProcessEnginesAppPathCamundaTest.shouldRedirectRequestToTasklist_contextRoot`
- `ResourceLoadingProcessEnginesAppPathRootIndexRedirectTest.shouldRedirectToTasklist`
- `ResourceLoadingProcessEnginesAppPathRootTest.shouldRedirectToStaticContent`

The tests expect a redirect to Tasklist (or the static `index.html`), but the assertions show Spring Security's **default login page** (`default-ui.css`, "Sign in") being served instead. The same tests are green on the Spring Boot 3 line.

## Root cause

The SB4 migration changed the test class `ContainerBasedAuthFilterRegistration` from Boot 3's `SecurityProperties.BASIC_AUTH_ORDER` to Boot 4's `SecurityFilterProperties.BASIC_AUTH_ORDER`, and added `spring-boot-security` as a test dependency so it compiles.

The difference between the two Boot lines:

- **Boot 3**: `SecurityProperties` lives in `spring-boot-autoconfigure`, which does **not** depend on Spring Security. Nothing security-related is on this module's test classpath, so no auto-configuration activates.
- **Boot 4**: `SecurityFilterProperties` lives in the new `spring-boot-security` module, which has **mandatory compile dependencies** on `spring-security-config` and `spring-security-web` (verified in `spring-boot-security-4.0.7.pom`).

With Spring Security on the test classpath, Boot 4's `SecurityAutoConfiguration` / `ServletWebSecurityAutoConfiguration` / `SecurityFilterAutoConfiguration` activate and put every request behind the default form login, so requests never reach the CadenzaFlow redirect filter or static resources. The module's own integration tests (e.g. `ChangedAppPathIT.shouldCheckPresenceOfSecurityFilter`, which expects CadenzaFlow's *own* SecurityFilter to answer 401) would break under the failsafe profile for the same reason.

## Fix

1. **`starter-webapp-core/pom.xml`**: remove the test-scope `spring-boot-security` dependency (with a comment warning against re-adding it). `spring-boot-jdbc` stays — it is genuinely needed for the Boot 4 split DataSource auto-configuration.
2. **`ContainerBasedAuthFilterRegistration`** (test): use `Ordered.LOWEST_PRECEDENCE - 20`, the exact same value as `SecurityFilterProperties.BASIC_AUTH_ORDER - 15` (`2147483642 - 15 = 2147483647 - 20`), without dragging Spring Security onto the classpath. This restores the SB3-equivalent test classpath.
3. **`starter/src/test/resources/application-default.properties`**: update the `spring.autoconfigure.exclude` entry from the Boot 3 FQCN (`org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration`, which no longer exists in Boot 4 and was silently ignored) to the Boot 4 name (`org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration`).

## Second latent bug this PR uncovered (and fixes): `TestRestTemplate` wiring

On master, `starter-webapp-core-4`'s failure made Maven (`--fail-at-end`) **skip** the downstream `starter-webapp-4` and `starter-security-4` modules, so their tests had never run in CI. With the security fix in place, `starter-webapp-4` ran for the first time and `WebappTest` failed:

```
No qualifying bean of type 'org.springframework.boot.resttestclient.TestRestTemplate' available
```

Cause: in Spring Boot 4, `spring-boot-resttestclient` no longer auto-registers a `TestRestTemplate` bean for `webEnvironment = RANDOM_PORT` tests (the Boot 3 `spring.factories` context customizer is gone). The bean now comes from `TestRestTemplateTestAutoConfiguration`, activated by annotating the test class with `@AutoConfigureTestRestTemplate` (verified against the `spring-boot-resttestclient-4.0.7.jar` metadata: no `spring.factories`, only `META-INF/spring/...AutoConfigureTestRestTemplate.imports`).

Fix (two parts):

1. Added `@AutoConfigureTestRestTemplate` to every SB4 test class that `@Autowired`s a `TestRestTemplate` — `WebappTest` (the CI blocker) plus the IT classes in `starter`, `starter-rest`, `starter-webapp-core`, and `starter-security` (via their `AbstractSpringSecurityIT` base), so the same wall doesn't reappear when ITs run under the integration-test profile. `RequestTrailingSlashIT` constructs its template manually and needs no annotation.
2. Added `spring-boot-restclient` (test scope) next to `spring-boot-resttestclient` in the five affected starter poms: `TestRestTemplateTestAutoConfiguration` builds on `RestTemplateBuilder`, which Boot 4 moved into `spring-boot-restclient`, and `spring-boot-resttestclient` does not pull it in transitively (its pom only requires `spring-boot-test`, `spring-boot-http-converter`, `spring-web`). Without it the context fails with `NoClassDefFoundError: org/springframework/boot/restclient/RestTemplateBuilder`.

`starter-security-4` has only `*IT` classes, so once `starter-webapp-4` is green the remaining chain passes surefire trivially.

## Consumer impact check

No product-code change needed: the bad dependency was **test-scoped**, so it never leaked to consumers of the published starter. `starter-security-4` is wired correctly for Boot 4 already (its `AutoConfiguration.imports` registers by class name and its sources import the new `SecurityFilterProperties` with a proper main-scope `spring-boot-starter-security` dependency).

## Verification

- `starter-webapp-core` unit tests in Docker (`maven:3.9-eclipse-temurin-17`, JDK 17): **all 33 tests green**, including the 4 previously failing redirect tests.
- Full `spring-boot-starter-4` tree surefire run in Docker after the `@AutoConfigureTestRestTemplate` fix: **all 7 modules SUCCESS** — `starter` 182 tests, `starter-webapp-core` 33 (incl. the 4 redirect tests), `starter-webapp` 2 (`WebappTest`), `starter-client` 8, zero failures/errors.
- CI (`test.yml`) runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
