### PR TITLE
fix(client): reserve external task client IT ports dynamically

### DIFF
--- a/clients/java/client/pom.xml
+++ b/clients/java/client/pom.xml
@@ -16,15 +16,13 @@
   <properties>
     <engine.runtime>${project.build.directory}/cadenzaflow-tomcat</engine.runtime>
     <tomcat.runtime>${engine.runtime}/server/apache-tomcat-${version.tomcat}</tomcat.runtime>
-    <http.port>${tomcat.connector.http.port}</http.port>
 
-    <tomcat.connector.http.port>50080</tomcat.connector.http.port>
-    <tomcat.connector.http.redirectPort>50443</tomcat.connector.http.redirectPort>
-    <tomcat.connector.ajp.port>50009</tomcat.connector.ajp.port>
-    <tomcat.connector.ajp.redirectPort>50443</tomcat.connector.ajp.redirectPort>
-    <tomcat.server.port>50005</tomcat.server.port>
+    <!-- it.http.port, it.ajp.port and it.rmi.port are reserved at build time by
+         build-helper:reserve-network-port so that concurrent builds on the same
+         machine cannot collide on fixed ports. They must not get default values
+         here: a value set in <properties> would be interpolated into the plugin
+         configurations when the POM is loaded, before the ports are reserved. -->
 
-    <cargo.servlet.port>59080</cargo.servlet.port>
     <cargo.timeout>240000</cargo.timeout>
     <cargo.deploy.timeout>60000</cargo.deploy.timeout>
   </properties>
@@ -176,6 +174,20 @@
         <artifactId>build-helper-maven-plugin</artifactId>
         <executions>
           <execution>
+            <id>reserve-it-ports</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>reserve-network-port</goal>
+            </goals>
+            <configuration>
+              <portNames>
+                <portName>it.http.port</portName>
+                <portName>it.ajp.port</portName>
+                <portName>it.rmi.port</portName>
+              </portNames>
+            </configuration>
+          </execution>
+          <execution>
             <id>add-it-source</id>
             <phase>generate-test-sources</phase>
             <goals>
@@ -273,7 +285,9 @@
             <type>standalone</type>
             <home>${project.build.directory}/cargo-config-tomcat</home>
             <properties>
-              <cargo.tomcat.ajp.port>${tomcat.connector.ajp.port}</cargo.tomcat.ajp.port>
+              <cargo.servlet.port>${it.http.port}</cargo.servlet.port>
+              <cargo.tomcat.ajp.port>${it.ajp.port}</cargo.tomcat.ajp.port>
+              <cargo.rmi.port>${it.rmi.port}</cargo.rmi.port>
               <cargo.start.jvmargs>-Djava.security.egd=file:/dev/./urandom</cargo.start.jvmargs>
             </properties>
             <files>
@@ -292,7 +306,7 @@
               <type>war</type>
               <classifier>tomcat</classifier>
               <pingURL>
-                http://localhost:${cargo.servlet.port}/engine-rest/engine/default/process-definition
+                http://localhost:${it.http.port}/engine-rest/engine/default/process-definition
               </pingURL>
               <pingTimeout>${cargo.deploy.timeout}</pingTimeout>
               <properties>
@@ -312,8 +326,21 @@
     </plugins>
 
     <testResources>
+      <!-- integration-rules.properties must advertise the engine-rest URL on the
+           dynamically reserved it.http.port; everything else is copied verbatim
+           so that BPMN models and test files are never touched by filtering. -->
       <testResource>
         <directory>src/it/resources</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>integration-rules.properties</include>
+        </includes>
+      </testResource>
+      <testResource>
+        <directory>src/it/resources</directory>
+        <excludes>
+          <exclude>integration-rules.properties</exclude>
+        </excludes>
       </testResource>
       <testResource>
         <directory>src/test/resources</directory>

--- a/clients/java/client/src/it/resources/integration-rules.properties
+++ b/clients/java/client/src/it/resources/integration-rules.properties
@@ -1,3 +1,5 @@
 #for tests internal usage only
-cadenzaflow.engine.rest=http://localhost:59080/engine-rest
+#the port placeholder is filled in by Maven resource filtering from the
+#build-time reserved it.http.port (see pom.xml)
+cadenzaflow.engine.rest=http://localhost:${it.http.port}/engine-rest
 cadenzaflow.engine.name=/engine/default


### PR DESCRIPTION
## Problem

`clients/java/client` starts a cargo-managed Tomcat for its integration tests on fixed ports inherited from upstream Camunda: `cargo.servlet.port` **59080**, AJP **50009**, and the implicit cargo default shutdown port **8205**. On the persistent self-hosted runner, any concurrent or leaked listener on 59080 — e.g. a Tomcat orphaned by a run cancelled through `cancel-in-progress: true` — makes cargo start fail with:

```
Port number 59080 is in use
```

which fails the module and skips everything downstream of it in the reactor (including the SB3/SB4 client starters). Seen in Test run 28885251527.

## Fix

- `build-helper:reserve-network-port` (version 1.9.1, already managed in `parent/pom.xml`) reserves three free ports — `it.http.port`, `it.ajp.port`, `it.rmi.port` — in the `process-resources` phase of every build.
- cargo consumes them through explicit configuration properties (`cargo.servlet.port`, `cargo.tomcat.ajp.port`, `cargo.rmi.port` — the shutdown port previously sat on the cargo default 8205, also a collision candidate), and the deployable `pingURL` uses `${it.http.port}`.
- `integration-rules.properties` no longer hardcodes `http://localhost:59080/engine-rest`; Maven resource filtering injects the reserved port. Only that single file is filtered — BPMN models and the other IT resources are copied verbatim.
- The fixed-port `<properties>` block (50080/50443/50009/50005/59080, plus the unused `http.port` alias) is removed. The reserved properties deliberately have **no defaults** in `<properties>`: a default value would be interpolated into the plugin configurations at POM load time, before the ports are reserved, and would silently pin the build back to fixed ports.

## Verification (Docker, `maven:3.9-eclipse-temurin-17`, `TZ=Europe/Berlin`)

- [x] `mvn -f clients/java/pom.xml verify` — **BUILD SUCCESS**, 263 integration tests, 0 failures/errors. Reserved ports that run: `it.http.port=43593`, `it.ajp.port=36273`, `it.rmi.port=36893`; the generated cargo `server.xml` and the filtered `target/test-classes/integration-rules.properties` were spot-checked to carry the reserved port.
- [x] Collision regression test: two full `clients/java` `verify` builds running **concurrently in the same network namespace** (one container, two working copies) — the scenario that killed run 28885251527. Both **BUILD SUCCESS**, 263 ITs each, zero `port ... in use` errors; the six reserved ports were all distinct (A: 37021/34169/38701, B: 34779/33387/44335). With the old fixed 59080 one of the two would fail deterministically.

## Note on `test.yml`

`test.yml` builds with `-DskipITs`, which skips failsafe but **not** cargo (its skip is bound to `${skipTests}`), so the Tomcat container still boots during push-scope CI — that boot is what collided in run 28885251527. With dynamic ports it can no longer collide. If we also want to reclaim the wasted container boot time there, a follow-up can add `-Dcargo.maven.skip=true` to the CI mvn call; CodeQL (`-DskipTests`, GitHub-hosted) is unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
