### PR TITLE
ci(codeql): grant security-events write permission for SARIF upload

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,15 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+
+# SARIF upload to code scanning needs security-events: write; without an explicit
+# permissions block the default token is read-only and the upload step fails with
+# "Resource not accessible by integration" (every master push since PR #10).
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

Every **master-push** CodeQL run has failed since PR #10 (2026-06-30) — including the merges of #15 and #16 — while PR-context runs pass. The analysis itself completes (8640 files scanned, SARIF exported); the failure is at the upload step:

```
##[error]Resource not accessible by integration - https://docs.github.com/rest
```

## Cause

`codeql.yml` has no `permissions:` block, so the job runs with the default read-only `GITHUB_TOKEN`, which cannot upload SARIF to code scanning (`security-events: write` required).

## Fix

Add the standard CodeQL permissions block (same as the GitHub starter workflow):

```yaml
permissions:
  actions: read
  contents: read
  security-events: write
```

No change to triggers, build, or queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)