### PR TITLE
feat(engine-rest): opt-in Keycloak OIDC Bearer authentication (roadmap item 3)

### DIFF
--- a/engine-rest/assembly-jakarta/src/main/runtime/tomcat/webapp/WEB-INF/web.xml
+++ b/engine-rest/assembly-jakarta/src/main/runtime/tomcat/webapp/WEB-INF/web.xml
@@ -70,6 +70,46 @@
     <url-pattern>/*</url-pattern>
   </filter-mapping> -->
 
+  <!-- Keycloak / OIDC Bearer Authentication Filter (alternative to Http Basic above).
+       Validates "Authorization: Bearer <JWT>" access tokens offline against the
+       issuer's JWKS - no call to the identity provider per request. Use
+       CompositeAuthenticationProvider to accept BOTH Bearer and Basic during a
+       migration, or KeycloakBearerTokenAuthenticationProvider for Bearer-only.
+       Only keycloak.issuer-uri and keycloak.audience are required; see
+       KeycloakProviderConfig for all parameters. Keycloak service-account tokens
+       (grant_type=client_credentials) usually carry the client id in the azp
+       claim, not aud - hence audience-mode=azp below. Prefer client_credentials
+       for machine-to-machine calls; grant_type=password (ROPC) is a legacy
+       convenience only. -->
+  <!-- <filter>
+    <filter-name>camunda-auth</filter-name>
+    <filter-class>
+      org.cadenzaflow.bpm.engine.rest.security.auth.ProcessEngineAuthenticationFilter
+    </filter-class>
+    <async-supported>true</async-supported>
+    <init-param>
+      <param-name>authentication-provider</param-name>
+      <param-value>org.cadenzaflow.bpm.engine.rest.security.auth.impl.CompositeAuthenticationProvider</param-value>
+    </init-param>
+    <init-param>
+      <param-name>keycloak.issuer-uri</param-name>
+      <param-value>https://keycloak.example.com/realms/my-realm</param-value>
+    </init-param>
+    <init-param>
+      <param-name>keycloak.audience</param-name>
+      <param-value>my-rest-client</param-value>
+    </init-param>
+    <init-param>
+      <param-name>keycloak.audience-mode</param-name>
+      <param-value>azp</param-value>
+    </init-param>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>camunda-auth</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping> -->
+
   <servlet>
     <servlet-name>Resteasy</servlet-name>
     <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>

--- a/engine-rest/assembly/src/main/runtime/tomcat/webapp/WEB-INF/web.xml
+++ b/engine-rest/assembly/src/main/runtime/tomcat/webapp/WEB-INF/web.xml
@@ -70,6 +70,46 @@
     <url-pattern>/*</url-pattern>
   </filter-mapping> -->
 
+  <!-- Keycloak / OIDC Bearer Authentication Filter (alternative to Http Basic above).
+       Validates "Authorization: Bearer <JWT>" access tokens offline against the
+       issuer's JWKS - no call to the identity provider per request. Use
+       CompositeAuthenticationProvider to accept BOTH Bearer and Basic during a
+       migration, or KeycloakBearerTokenAuthenticationProvider for Bearer-only.
+       Only keycloak.issuer-uri and keycloak.audience are required; see
+       KeycloakProviderConfig for all parameters. Keycloak service-account tokens
+       (grant_type=client_credentials) usually carry the client id in the azp
+       claim, not aud - hence audience-mode=azp below. Prefer client_credentials
+       for machine-to-machine calls; grant_type=password (ROPC) is a legacy
+       convenience only. -->
+  <!-- <filter>
+    <filter-name>camunda-auth</filter-name>
+    <filter-class>
+      org.cadenzaflow.bpm.engine.rest.security.auth.ProcessEngineAuthenticationFilter
+    </filter-class>
+    <async-supported>true</async-supported>
+    <init-param>
+      <param-name>authentication-provider</param-name>
+      <param-value>org.cadenzaflow.bpm.engine.rest.security.auth.impl.CompositeAuthenticationProvider</param-value>
+    </init-param>
+    <init-param>
+      <param-name>keycloak.issuer-uri</param-name>
+      <param-value>https://keycloak.example.com/realms/my-realm</param-value>
+    </init-param>
+    <init-param>
+      <param-name>keycloak.audience</param-name>
+      <param-value>my-rest-client</param-value>
+    </init-param>
+    <init-param>
+      <param-name>keycloak.audience-mode</param-name>
+      <param-value>azp</param-value>
+    </init-param>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>camunda-auth</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping> -->
+
   <servlet>
     <servlet-name>Resteasy</servlet-name>
     <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServlet30Dispatcher</servlet-class>

--- a/engine-rest/engine-rest-jakarta/pom.xml
+++ b/engine-rest/engine-rest-jakarta/pom.xml
@@ -43,6 +43,25 @@
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
     </dependency>
+    <dependency>
+      <!-- The jakarta module copies and transforms the javax TEST sources too,
+           so the Keycloak container IT needs testcontainers here as well.
+           Same version + exclusions as the javax module (see its pom). -->
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>1.21.3</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
     <dependency>
       <groupId>commons-fileupload</groupId>

--- a/engine-rest/engine-rest-jakarta/pom.xml
+++ b/engine-rest/engine-rest-jakarta/pom.xml
@@ -39,6 +39,12 @@
   <dependencies>
 
     <dependency>
+      <!-- OIDC Bearer token validation (KeycloakBearerTokenAuthenticationProvider); version managed in cadenzaflow-core-internal-dependencies -->
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
       <exclusions>

--- a/engine-rest/engine-rest/README.md
+++ b/engine-rest/engine-rest/README.md
@@ -3,6 +3,55 @@ REST API
 
 A JAX-RS-based REST API for Camunda Platform.
 
+OIDC Bearer Authentication (Keycloak)
+-------------------------------------
+
+Besides HTTP Basic, the REST API can authenticate requests with an OIDC access
+token: `Authorization: Bearer <JWT>`. The token is validated **offline** against
+the issuer's JWKS (signature, issuer, expiry, audience) — there is no call to
+the identity provider per request. How the client obtained the token
+(`client_credentials` or `password`) does not matter to the server.
+
+Enable it in `web.xml` by choosing the authentication provider (a ready-made
+commented example ships in the Tomcat distribution's `web.xml`):
+
+* `KeycloakBearerTokenAuthenticationProvider` — Bearer only
+* `CompositeAuthenticationProvider` — Bearer **and** Basic (migration mode:
+  existing Basic clients keep working unchanged)
+* `HttpBasicAuthenticationProvider` — Basic only (today's default; nothing
+  changes if you configure nothing)
+
+Filter init-params (only the first two are required):
+
+| Parameter | Default | Purpose |
+|---|---|---|
+| `keycloak.issuer-uri` | — | expected `iss` claim; also derives the JWKS URL (Keycloak convention) |
+| `keycloak.audience` | — | expected client id (checked against `aud` or `azp`) |
+| `keycloak.audience-mode` | `aud` | `aud` \| `azp` \| `any` — Keycloak service-account tokens usually carry the client id only in `azp`, so use `azp` (or `any`) for `client_credentials` clients |
+| `keycloak.jwks-uri` | derived from issuer | set explicitly for non-Keycloak OIDC providers (from the provider's discovery document) |
+| `keycloak.username-claim` | `preferred_username` | claim mapped to the engine user id (fallback: `keycloak.username-claim-fallback`, default `sub`) |
+| `keycloak.allowed-algorithms` | `RS256` | accepted JWS algorithms, comma-separated |
+| `keycloak.clock-skew-seconds` | `60` | `exp`/`nbf` tolerance |
+| `keycloak.jwks-cache-ttl-ms` / `keycloak.jwks-cache-refresh-timeout-ms` / `keycloak.jwks-min-interval-ms` | `300000` / `30000` / `30000` | JWKS cache lifetime / refresh-operation wait cap / unknown-`kid` refetch rate limit |
+
+Notes:
+
+* Groups and tenants are **never** read from the token — they resolve through
+  the engine's `IdentityService`, so UI and REST authorization always agree.
+* Missing or invalid required parameters fail the filter at deployment time
+  (`ServletException`), not silently at request time.
+* Prefer `grant_type=client_credentials` for machine-to-machine calls;
+  `grant_type=password` (ROPC) is accepted but is a legacy convenience —
+  OAuth 2.1 removes it.
+* Keycloak setup in short: create a **confidential** client (service accounts
+  enabled for `client_credentials`; "Direct Access Grants" only if you need
+  ROPC) and use the realm URL as `keycloak.issuer-uri`.
+
+An integration test against a real Keycloak exists and runs on demand
+(requires Docker):
+
+    mvn -pl engine-rest/engine-rest test -Dtest=KeycloakBearerTokenAuthenticationProviderContainerIT
+
 Running Tests
 -------------
 

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -20,6 +20,12 @@
 
   <dependencies>
     <dependency>
+      <!-- OIDC Bearer token validation (KeycloakBearerTokenAuthenticationProvider); version managed in cadenzaflow-core-internal-dependencies -->
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
       <exclusions>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -24,6 +24,16 @@
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
     </dependency>
+    <dependency>
+      <!-- Keycloak container IT (KeycloakBearerTokenAuthenticationProviderContainerIT).
+           Version OVERRIDES the managed 1.17.6 for this module only: the shaded
+           docker-java 3.2.13 in 1.17.6 speaks an API version modern Docker engines
+           (25+) reject with HTTP 400 at detection time. -->
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>1.21.3</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>commons-fileupload</groupId>

--- a/engine-rest/engine-rest/pom.xml
+++ b/engine-rest/engine-rest/pom.xml
@@ -33,6 +33,21 @@
       <artifactId>testcontainers</artifactId>
       <version>1.21.3</version>
       <scope>test</scope>
+      <exclusions>
+        <!-- TC declares slf4j-api 1.7.x and junit; being declared early in this
+             pom it would win dependency mediation and shadow the slf4j 2.x line
+             the existing test infra (logback 1.5, jcl/jul bridges 2.0.x,
+             ProcessEngineLoggingRule) relies on -> NoClassDefFoundError:
+             org.slf4j.spi.LoggingEventAware. The repo manages both itself. -->
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/engine-rest/engine-rest/src/main/java/org/cadenzaflow/bpm/engine/rest/security/auth/ConfigurableAuthenticationProvider.java
+++ b/engine-rest/engine-rest/src/main/java/org/cadenzaflow/bpm/engine/rest/security/auth/ConfigurableAuthenticationProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cadenzaflow.bpm.engine.rest.security.auth;
+
+import java.util.Map;
+
+import javax.servlet.ServletException;
+
+/**
+ * <p>
+ * Optional extension of {@link AuthenticationProvider}: implemented by providers
+ * that need configuration from the {@link ProcessEngineAuthenticationFilter}'s
+ * filter init-params.
+ * </p>
+ *
+ * <p>
+ * The filter instantiates providers with a no-arg constructor. If the provider
+ * also implements this interface, the filter calls {@link #configure(Map)} once
+ * during {@code Filter#init}, passing all filter init-params except the two the
+ * filter itself owns ({@code authentication-provider} and
+ * {@code rest-url-pattern-prefix}).
+ * </p>
+ *
+ * <p>
+ * Implementations should validate their required parameters and throw a
+ * {@link ServletException} on missing/invalid configuration, so that
+ * misconfiguration fails at deployment time instead of silently
+ * mis-authenticating requests.
+ * </p>
+ */
+public interface ConfigurableAuthenticationProvider {
+
+  /**
+   * Called once by {@link ProcessEngineAuthenticationFilter} during filter
+   * initialization, before the first request is served.
+   *
+   * @param parameters
+   *          all filter init-params except {@code authentication-provider} and
+   *          {@code rest-url-pattern-prefix}. Never <code>null</code>.
+   * @throws ServletException
+   *           if required parameters are missing or invalid; fails filter
+   *           initialization (deploy-time error)
+   */
+  void configure(Map<String, String> parameters) throws ServletException;
+}

--- a/engine-rest/engine-rest/src/main/java/org/cadenzaflow/bpm/engine/rest/security/auth/ProcessEngineAuthenticationFilter.java
+++ b/engine-rest/engine-rest/src/main/java/org/cadenzaflow/bpm/engine/rest/security/auth/ProcessEngineAuthenticationFilter.java
@@ -18,7 +18,10 @@ package org.cadenzaflow.bpm.engine.rest.security.auth;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -102,6 +105,19 @@ public class ProcessEngineAuthenticationFilter implements Filter {
     } catch (ClassCastException e) {
       throw new ServletException("Cannot instantiate authentication filter: authentication provider does not implement interface " +
           AuthenticationProvider.class.getName(), e);
+    }
+
+    if (authenticationProvider instanceof ConfigurableAuthenticationProvider) {
+      ConfigurableAuthenticationProvider configurableProvider = (ConfigurableAuthenticationProvider) authenticationProvider;
+      Map<String, String> providerParameters = new HashMap<String, String>();
+      Enumeration<String> parameterNames = filterConfig.getInitParameterNames();
+      while (parameterNames.hasMoreElements()) {
+        String parameterName = parameterNames.nextElement();
+        if (!AUTHENTICATION_PROVIDER_PARAM.equals(parameterName) && !SERVLET_PATH_PREFIX.equals(parameterName)) {
+          providerParameters.put(parameterName, filterConfig.getInitParameter(parameterName));
+        }
+      }
+      configurableProvider.configure(providerParameters);
     }
 
     servletPathPrefix = filterConfig.getInitParameter(SERVLET_PATH_PREFIX);

--- a/engine-rest/engine-rest/src/main/java/org/cadenzaflow/bpm/engine/rest/security/auth/impl/BearerTokenValidator.java
+++ b/engine-rest/engine-rest/src/main/java/org/cadenzaflow/bpm/engine/rest/security/auth/impl/BearerTokenValidator.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cadenzaflow.bpm.engine.rest.security.auth.impl;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import javax.servlet.ServletException;
+
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+
+/**
+ * <p>
+ * Offline JWT validation for Keycloak bearer tokens, built on nimbus-jose-jwt.
+ * Signature verification uses the issuer's JWKS, fetched once and cached
+ * in-memory — there is <b>no per-request round trip</b> to the identity
+ * provider. An unknown {@code kid} triggers a JWKS refetch, rate-limited by
+ * {@code keycloak.jwks-min-interval-ms} so unknown-kid bursts cannot hammer
+ * the IdP; after a key rotation the new key is picked up on the next refetch.
+ * </p>
+ *
+ * <p>
+ * All components are immutable after construction and safe for concurrent use
+ * (one instance is shared across requests by the authentication filter).
+ * </p>
+ */
+public class BearerTokenValidator {
+
+  protected final DefaultJWTProcessor<SecurityContext> processor;
+
+  public BearerTokenValidator(KeycloakProviderConfig config) throws ServletException {
+    this(config, buildJwkSource(config));
+  }
+
+  /**
+   * Seam for tests: allows an in-memory {@code JWKSource} (e.g.
+   * {@code ImmutableJWKSet}) instead of the URL-backed cached source.
+   */
+  protected BearerTokenValidator(KeycloakProviderConfig config, JWKSource<SecurityContext> jwkSource) {
+    DefaultJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<SecurityContext>();
+    jwtProcessor.setJWSKeySelector(new JWSVerificationKeySelector<SecurityContext>(config.expectedAlgs(), jwkSource));
+    jwtProcessor.setJWTClaimsSetVerifier(new KeycloakClaimsVerifier(config));
+    this.processor = jwtProcessor;
+  }
+
+  protected static JWKSource<SecurityContext> buildJwkSource(KeycloakProviderConfig config) throws ServletException {
+    URL jwksUrl;
+    try {
+      jwksUrl = new URL(config.jwksUri());
+    } catch (MalformedURLException e) {
+      throw new ServletException("Cannot initialize Keycloak bearer token authentication: JWKS URI '"
+          + config.jwksUri() + "' is not a valid URL", e);
+    }
+
+    return JWKSourceBuilder.create(jwksUrl)
+        .cache(config.jwksCacheTtlMs(), config.jwksCacheRefreshTimeoutMs())
+        .rateLimited(config.jwksMinIntervalMs())
+        .build();
+  }
+
+  /**
+   * Validates the given serialized JWT: signature against the (cached) JWKS,
+   * then all claim rules ({@link KeycloakClaimsVerifier}).
+   *
+   * @return the verified claims
+   * @throws Exception
+   *           if the token is malformed, unsigned, has a bad signature or
+   *           violates any claim rule ({@code ParseException},
+   *           {@code BadJOSEException}, {@code BadJWTException}, ...)
+   */
+  public JWTClaimsSet validate(String token) throws Exception {
+    return processor.process(SignedJWT.parse(token), null);
+  }
+}

--- a/engine-rest/engine-rest/src/main/java/org/cadenzaflow/bpm/engine/rest/security/auth/impl/CompositeAuthenticationProvider.java
+++ b/engine-rest/engine-rest/src/main/java/org/cadenzaflow/bpm/engine/rest/security/auth/impl/CompositeAuthenticationProvider.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cadenzaflow.bpm.engine.rest.security.auth.impl;
+
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
+
+import org.cadenzaflow.bpm.engine.ProcessEngine;
+import org.cadenzaflow.bpm.engine.rest.security.auth.AuthenticationProvider;
+import org.cadenzaflow.bpm.engine.rest.security.auth.AuthenticationResult;
+import org.cadenzaflow.bpm.engine.rest.security.auth.ConfigurableAuthenticationProvider;
+
+/**
+ * <p>
+ * Mixed-mode authentication: dispatches on the {@code Authorization} scheme.
+ * {@code Bearer} requests are validated as Keycloak OIDC tokens
+ * ({@link KeycloakBearerTokenAuthenticationProvider}); everything else —
+ * {@code Basic} or no header — takes today's HTTP Basic path
+ * ({@link HttpBasicAuthenticationProvider}), unchanged. This is the
+ * backward-compatible migration mode: existing Basic clients keep working
+ * while OIDC clients move to tokens.
+ * </p>
+ */
+public class CompositeAuthenticationProvider
+    implements AuthenticationProvider, ConfigurableAuthenticationProvider {
+
+  protected final KeycloakBearerTokenAuthenticationProvider bearerProvider;
+  protected final HttpBasicAuthenticationProvider basicProvider;
+
+  public CompositeAuthenticationProvider() {
+    this(new KeycloakBearerTokenAuthenticationProvider(), new HttpBasicAuthenticationProvider());
+  }
+
+  /** Composition seam (also used by tests to inject an in-memory-JWKS bearer provider). */
+  public CompositeAuthenticationProvider(KeycloakBearerTokenAuthenticationProvider bearerProvider,
+      HttpBasicAuthenticationProvider basicProvider) {
+    this.bearerProvider = bearerProvider;
+    this.basicProvider = basicProvider;
+  }
+
+  @Override
+  public void configure(Map<String, String> parameters) throws ServletException {
+    // only the bearer side needs configuration; Basic has none
+    bearerProvider.configure(parameters);
+  }
+
+  @Override
+  public AuthenticationResult extractAuthenticatedUser(HttpServletRequest request, ProcessEngine engine) {
+    String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+    if (authorizationHeader != null
+        && authorizationHeader.startsWith(KeycloakBearerTokenAuthenticationProvider.BEARER_AUTH_HEADER_PREFIX)) {
+      return bearerProvider.extractAuthenticatedUser(request, engine);
+    }
+
+    // Basic or no header: byte-for-byte today's behavior
+    return basicProvider.extractAuthenticatedUser(request, engine);
+  }
+
+  @Override
+  public void augmentResponseByAuthenticationChallenge(HttpServletResponse response, ProcessEngine engine) {
+    // The underlying providers both use setHeader(), which would overwrite each
+    // other (only the last scheme would be advertised). Emit both challenges here
+    // with addHeader() so a client sees Bearer AND Basic; realm-only per RFC 6750
+    // (see KeycloakBearerTokenAuthenticationProvider).
+    response.addHeader(HttpHeaders.WWW_AUTHENTICATE, "Bearer realm=\"" + engine.getName() + "\"");
+    response.addHeader(HttpHeaders.WWW_AUTHENTICATE, "Basic realm=\"" + engine.getName() + "\"");
+  }
+}

--- a/engine-rest/engine-rest/src/main/java/org/cadenzaflow/bpm/engine/rest/security/auth/impl/KeycloakBearerTokenAuthenticationProvider.java
+++ b/engine-rest/engine-rest/src/main/java/org/cadenzaflow/bpm/engine/rest/security/auth/impl/KeycloakBearerTokenAuthenticationProvider.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cadenzaflow.bpm.engine.rest.security.auth.impl;
+
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
+
+import org.cadenzaflow.bpm.engine.ProcessEngine;
+import org.cadenzaflow.bpm.engine.rest.security.auth.AuthenticationProvider;
+import org.cadenzaflow.bpm.engine.rest.security.auth.AuthenticationResult;
+import org.cadenzaflow.bpm.engine.rest.security.auth.ConfigurableAuthenticationProvider;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+
+/**
+ * <p>
+ * Authenticates a request by validating a Keycloak (OIDC) JWT access token
+ * from the {@code Authorization: Bearer} header — offline, against the
+ * issuer's cached JWKS ({@link BearerTokenValidator}). How the client obtained
+ * the token ({@code client_credentials}, {@code password}, ...) is
+ * deliberately irrelevant here: any valid JWT from the configured issuer is
+ * accepted.
+ * </p>
+ *
+ * <p>
+ * On success only the user id (from the configured username claim, default
+ * {@code preferred_username}, fallback {@code sub}) is returned — groups and
+ * tenants are deliberately NOT read from the token; they resolve through the
+ * engine's {@code IdentityService} (see
+ * {@code ProcessEngineAuthenticationFilter#setAuthenticatedUser}), which is
+ * backed by the Keycloak identity provider plugin when configured. One
+ * identity source for webapps and REST.
+ * </p>
+ *
+ * <p>
+ * Configuration comes from filter init-params via
+ * {@link ConfigurableAuthenticationProvider#configure(Map)} — see
+ * {@link KeycloakProviderConfig} for the parameter reference. The
+ * {@code "Bearer "} prefix match is case-sensitive by choice, consistent with
+ * {@link HttpBasicAuthenticationProvider}'s {@code "Basic "} handling.
+ * </p>
+ */
+public class KeycloakBearerTokenAuthenticationProvider
+    implements AuthenticationProvider, ConfigurableAuthenticationProvider {
+
+  protected static final String BEARER_AUTH_HEADER_PREFIX = "Bearer ";
+
+  protected BearerTokenValidator validator;
+  protected String usernameClaim = "preferred_username";
+  protected String fallbackClaim = "sub";
+
+  @Override
+  public void configure(Map<String, String> parameters) throws ServletException {
+    KeycloakProviderConfig config = KeycloakProviderConfig.fromInitParams(parameters);
+    this.usernameClaim = config.usernameClaim();
+    this.fallbackClaim = config.fallbackClaim();
+    this.validator = createValidator(config);
+  }
+
+  /** Seam for tests: override to supply a validator with an in-memory JWKS. */
+  protected BearerTokenValidator createValidator(KeycloakProviderConfig config) throws ServletException {
+    return new BearerTokenValidator(config);
+  }
+
+  @Override
+  public AuthenticationResult extractAuthenticatedUser(HttpServletRequest request, ProcessEngine engine) {
+    String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+    if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_AUTH_HEADER_PREFIX)) {
+      return AuthenticationResult.unsuccessful();
+    }
+
+    if (validator == null) {
+      // configure(Map) was never called (provider used outside the filter without
+      // configuration) — treat as unauthenticated rather than failing with an NPE
+      return AuthenticationResult.unsuccessful();
+    }
+
+    String token = authorizationHeader.substring(BEARER_AUTH_HEADER_PREFIX.length()).trim();
+    if (token.isEmpty()) {
+      return AuthenticationResult.unsuccessful();
+    }
+
+    try {
+      JWTClaimsSet claims = validator.validate(token);
+
+      String user = claims.getStringClaim(usernameClaim);
+      if (user == null || user.isEmpty()) {
+        user = claims.getStringClaim(fallbackClaim);
+      }
+      if (user == null || user.isEmpty()) {
+        return AuthenticationResult.unsuccessful();
+      }
+
+      // no groups/tenants: the filter resolves them via the IdentityService
+      return AuthenticationResult.successful(user);
+    } catch (Exception e) {
+      // never leak the token or the specific validation failure to the caller
+      return AuthenticationResult.unsuccessful();
+    }
+  }
+
+  @Override
+  public void augmentResponseByAuthenticationChallenge(HttpServletResponse response, ProcessEngine engine) {
+    // Realm-only challenge: this callback fires for EVERY 401 — including requests
+    // that sent no Authorization header at all — and RFC 6750 §3 forbids an error
+    // code when no credentials were presented. The callback cannot distinguish
+    // missing vs. invalid, so the error attribute is omitted.
+    response.setHeader(HttpHeaders.WWW_AUTHENTICATE, "Bearer realm=\"" + engine.getName() + "\"");
+  }
+}

--- a/engine-rest/engine-rest/src/main/java/org/cadenzaflow/bpm/engine/rest/security/auth/impl/KeycloakClaimsVerifier.java
+++ b/engine-rest/engine-rest/src/main/java/org/cadenzaflow/bpm/engine/rest/security/auth/impl/KeycloakClaimsVerifier.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cadenzaflow.bpm.engine.rest.security.auth.impl;
+
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import org.cadenzaflow.bpm.engine.rest.security.auth.impl.KeycloakProviderConfig.AudienceMode;
+
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.BadJWTException;
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
+
+/**
+ * <p>
+ * Claim verification for Keycloak bearer tokens: one class owns the whole
+ * claim rule. Issuer exact-match, {@code exp}/{@code nbf} (with clock-skew
+ * tolerance) and — in {@link AudienceMode#AUD} mode — the audience check are
+ * enforced by the {@link DefaultJWTClaimsVerifier} superclass; the
+ * {@code azp}/{@code any} audience modes are enforced in
+ * {@link #verify(JWTClaimsSet, SecurityContext)}.
+ * </p>
+ *
+ * <p>
+ * Keycloak {@code client_credentials} (service-account) tokens often carry the
+ * client id only in {@code azp} and no {@code aud} claim at all — the
+ * {@code azp}/{@code any} modes exist so that flow works instead of silently
+ * failing with 401.
+ * </p>
+ */
+public class KeycloakClaimsVerifier extends DefaultJWTClaimsVerifier<SecurityContext> {
+
+  protected final KeycloakProviderConfig config;
+
+  public KeycloakClaimsVerifier(KeycloakProviderConfig config) {
+    super(
+        // 4-arg constructor takes Set<String> acceptedAudience; null skips the
+        // native aud check entirely (AZP/ANY modes enforce audience below)
+        config.audienceMode() == AudienceMode.AUD
+            ? Collections.singleton(config.audience())
+            : null,
+        new JWTClaimsSet.Builder().issuer(config.issuer()).build(),
+        new HashSet<String>(Arrays.asList("exp")),
+        null);
+    setMaxClockSkew(config.clockSkewSeconds());
+    this.config = config;
+  }
+
+  @Override
+  public void verify(JWTClaimsSet claims, SecurityContext context) throws BadJWTException {
+    super.verify(claims, context); // iss, exp/nbf (+skew); aud too when mode == AUD
+
+    if (config.audienceMode() != AudienceMode.AUD) {
+      String azp;
+      try {
+        azp = claims.getStringClaim("azp");
+      } catch (ParseException e) {
+        throw new BadJWTException("JWT azp claim is not a string", e);
+      }
+
+      boolean matches;
+      if (config.audienceMode() == AudienceMode.AZP) {
+        matches = config.audience().equals(azp);
+      } else { // ANY: configured value in aud OR equals azp
+        List<String> audience = claims.getAudience();
+        matches = config.audience().equals(azp)
+            || (audience != null && audience.contains(config.audience()));
+      }
+
+      if (!matches) {
+        throw new BadJWTException("JWT audience/azp does not match the expected client");
+      }
+    }
+  }
+}

--- a/engine-rest/engine-rest/src/main/java/org/cadenzaflow/bpm/engine/rest/security/auth/impl/KeycloakProviderConfig.java
+++ b/engine-rest/engine-rest/src/main/java/org/cadenzaflow/bpm/engine/rest/security/auth/impl/KeycloakProviderConfig.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cadenzaflow.bpm.engine.rest.security.auth.impl;
+
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.ServletException;
+
+import com.nimbusds.jose.JWSAlgorithm;
+
+/**
+ * <p>
+ * Configuration holder for {@link KeycloakBearerTokenAuthenticationProvider},
+ * parsed from the authentication filter's init-params (see
+ * {@code ConfigurableAuthenticationProvider}). All parameters are non-secret
+ * (URLs, ids, claim names, tolerances) — the provider only validates tokens
+ * and never talks to the token endpoint, so no client secret is configured.
+ * </p>
+ *
+ * <p>Parameters (defaults in parentheses):</p>
+ * <ul>
+ *   <li>{@code keycloak.issuer-uri} — required; expected {@code iss} claim value</li>
+ *   <li>{@code keycloak.jwks-uri} — ({issuer}/protocol/openid-connect/certs, the
+ *       Keycloak convention; set explicitly for other OIDC providers)</li>
+ *   <li>{@code keycloak.audience} — required; expected {@code aud}/{@code azp} value</li>
+ *   <li>{@code keycloak.audience-mode} — aud | azp | any (aud)</li>
+ *   <li>{@code keycloak.username-claim} — (preferred_username)</li>
+ *   <li>{@code keycloak.username-claim-fallback} — (sub)</li>
+ *   <li>{@code keycloak.allowed-algorithms} — comma-separated JWS algorithms (RS256)</li>
+ *   <li>{@code keycloak.clock-skew-seconds} — exp/nbf tolerance (60)</li>
+ *   <li>{@code keycloak.jwks-cache-ttl-ms} — JWKS cache lifetime (300000)</li>
+ *   <li>{@code keycloak.jwks-cache-refresh-timeout-ms} — max wait for a JWKS cache
+ *       refresh operation (30000); NOT refresh-ahead</li>
+ *   <li>{@code keycloak.jwks-min-interval-ms} — min interval between JWKS refetches,
+ *       rate limit for unknown-kid bursts (30000)</li>
+ * </ul>
+ *
+ * <p>Unknown parameters are ignored; missing/invalid required parameters fail
+ * with a {@link ServletException} so that misconfiguration surfaces at
+ * deployment time.</p>
+ */
+public class KeycloakProviderConfig {
+
+  public enum AudienceMode {
+    AUD, AZP, ANY
+  }
+
+  public static final String PARAM_ISSUER_URI = "keycloak.issuer-uri";
+  public static final String PARAM_JWKS_URI = "keycloak.jwks-uri";
+  public static final String PARAM_AUDIENCE = "keycloak.audience";
+  public static final String PARAM_AUDIENCE_MODE = "keycloak.audience-mode";
+  public static final String PARAM_USERNAME_CLAIM = "keycloak.username-claim";
+  public static final String PARAM_USERNAME_CLAIM_FALLBACK = "keycloak.username-claim-fallback";
+  public static final String PARAM_ALLOWED_ALGORITHMS = "keycloak.allowed-algorithms";
+  public static final String PARAM_CLOCK_SKEW_SECONDS = "keycloak.clock-skew-seconds";
+  public static final String PARAM_JWKS_CACHE_TTL_MS = "keycloak.jwks-cache-ttl-ms";
+  public static final String PARAM_JWKS_CACHE_REFRESH_TIMEOUT_MS = "keycloak.jwks-cache-refresh-timeout-ms";
+  public static final String PARAM_JWKS_MIN_INTERVAL_MS = "keycloak.jwks-min-interval-ms";
+
+  protected static final String KEYCLOAK_CERTS_PATH = "/protocol/openid-connect/certs";
+
+  protected final String issuer;
+  protected final String jwksUri;
+  protected final String audience;
+  protected final AudienceMode audienceMode;
+  protected final String usernameClaim;
+  protected final String fallbackClaim;
+  protected final Set<JWSAlgorithm> expectedAlgs;
+  protected final int clockSkewSeconds;
+  protected final long jwksCacheTtlMs;
+  protected final long jwksCacheRefreshTimeoutMs;
+  protected final long jwksMinIntervalMs;
+
+  protected KeycloakProviderConfig(String issuer, String jwksUri, String audience, AudienceMode audienceMode,
+      String usernameClaim, String fallbackClaim, Set<JWSAlgorithm> expectedAlgs, int clockSkewSeconds,
+      long jwksCacheTtlMs, long jwksCacheRefreshTimeoutMs, long jwksMinIntervalMs) {
+    this.issuer = issuer;
+    this.jwksUri = jwksUri;
+    this.audience = audience;
+    this.audienceMode = audienceMode;
+    this.usernameClaim = usernameClaim;
+    this.fallbackClaim = fallbackClaim;
+    this.expectedAlgs = expectedAlgs;
+    this.clockSkewSeconds = clockSkewSeconds;
+    this.jwksCacheTtlMs = jwksCacheTtlMs;
+    this.jwksCacheRefreshTimeoutMs = jwksCacheRefreshTimeoutMs;
+    this.jwksMinIntervalMs = jwksMinIntervalMs;
+  }
+
+  public static KeycloakProviderConfig fromInitParams(Map<String, String> parameters) throws ServletException {
+    String issuer = required(parameters, PARAM_ISSUER_URI);
+    String audience = required(parameters, PARAM_AUDIENCE);
+
+    String jwksUri = trimmedOrNull(parameters.get(PARAM_JWKS_URI));
+    if (jwksUri == null) {
+      // Keycloak convention; non-Keycloak IdPs configure keycloak.jwks-uri explicitly
+      String base = issuer.endsWith("/") ? issuer.substring(0, issuer.length() - 1) : issuer;
+      jwksUri = base + KEYCLOAK_CERTS_PATH;
+    }
+
+    AudienceMode audienceMode = parseAudienceMode(parameters.get(PARAM_AUDIENCE_MODE));
+
+    String usernameClaim = defaulted(parameters.get(PARAM_USERNAME_CLAIM), "preferred_username");
+    String fallbackClaim = defaulted(parameters.get(PARAM_USERNAME_CLAIM_FALLBACK), "sub");
+
+    Set<JWSAlgorithm> expectedAlgs = parseAlgorithms(defaulted(parameters.get(PARAM_ALLOWED_ALGORITHMS), "RS256"));
+
+    int clockSkewSeconds = (int) parseNonNegativeLong(parameters, PARAM_CLOCK_SKEW_SECONDS, 60L);
+    long jwksCacheTtlMs = parseNonNegativeLong(parameters, PARAM_JWKS_CACHE_TTL_MS, 300000L);
+    long jwksCacheRefreshTimeoutMs = parseNonNegativeLong(parameters, PARAM_JWKS_CACHE_REFRESH_TIMEOUT_MS, 30000L);
+    long jwksMinIntervalMs = parseNonNegativeLong(parameters, PARAM_JWKS_MIN_INTERVAL_MS, 30000L);
+
+    return new KeycloakProviderConfig(issuer, jwksUri, audience, audienceMode, usernameClaim, fallbackClaim,
+        expectedAlgs, clockSkewSeconds, jwksCacheTtlMs, jwksCacheRefreshTimeoutMs, jwksMinIntervalMs);
+  }
+
+  protected static String required(Map<String, String> parameters, String name) throws ServletException {
+    String value = trimmedOrNull(parameters.get(name));
+    if (value == null) {
+      throw new ServletException("Cannot initialize Keycloak bearer token authentication: required init-param '"
+          + name + "' is missing or empty");
+    }
+    return value;
+  }
+
+  protected static String trimmedOrNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
+
+  protected static String defaulted(String value, String defaultValue) {
+    String trimmed = trimmedOrNull(value);
+    return trimmed == null ? defaultValue : trimmed;
+  }
+
+  protected static AudienceMode parseAudienceMode(String value) throws ServletException {
+    String mode = defaulted(value, "aud").toLowerCase(Locale.ROOT);
+    if ("aud".equals(mode)) {
+      return AudienceMode.AUD;
+    } else if ("azp".equals(mode)) {
+      return AudienceMode.AZP;
+    } else if ("any".equals(mode)) {
+      return AudienceMode.ANY;
+    }
+    throw new ServletException("Cannot initialize Keycloak bearer token authentication: init-param '"
+        + PARAM_AUDIENCE_MODE + "' must be one of aud|azp|any but was '" + value + "'");
+  }
+
+  protected static Set<JWSAlgorithm> parseAlgorithms(String value) throws ServletException {
+    Set<JWSAlgorithm> algorithms = new HashSet<JWSAlgorithm>();
+    for (String name : value.split(",")) {
+      String trimmed = name.trim();
+      if (!trimmed.isEmpty()) {
+        algorithms.add(JWSAlgorithm.parse(trimmed));
+      }
+    }
+    if (algorithms.isEmpty()) {
+      throw new ServletException("Cannot initialize Keycloak bearer token authentication: init-param '"
+          + PARAM_ALLOWED_ALGORITHMS + "' must contain at least one JWS algorithm");
+    }
+    return algorithms;
+  }
+
+  protected static long parseNonNegativeLong(Map<String, String> parameters, String name, long defaultValue)
+      throws ServletException {
+    String value = trimmedOrNull(parameters.get(name));
+    if (value == null) {
+      return defaultValue;
+    }
+    try {
+      long parsed = Long.parseLong(value);
+      if (parsed < 0) {
+        throw new NumberFormatException("negative");
+      }
+      return parsed;
+    } catch (NumberFormatException e) {
+      throw new ServletException("Cannot initialize Keycloak bearer token authentication: init-param '"
+          + name + "' must be a non-negative number but was '" + value + "'");
+    }
+  }
+
+  public String issuer() {
+    return issuer;
+  }
+
+  public String jwksUri() {
+    return jwksUri;
+  }
+
+  public String audience() {
+    return audience;
+  }
+
+  public AudienceMode audienceMode() {
+    return audienceMode;
+  }
+
+  public String usernameClaim() {
+    return usernameClaim;
+  }
+
+  public String fallbackClaim() {
+    return fallbackClaim;
+  }
+
+  public Set<JWSAlgorithm> expectedAlgs() {
+    return expectedAlgs;
+  }
+
+  public int clockSkewSeconds() {
+    return clockSkewSeconds;
+  }
+
+  public long jwksCacheTtlMs() {
+    return jwksCacheTtlMs;
+  }
+
+  public long jwksCacheRefreshTimeoutMs() {
+    return jwksCacheRefreshTimeoutMs;
+  }
+
+  public long jwksMinIntervalMs() {
+    return jwksMinIntervalMs;
+  }
+}

--- a/engine-rest/engine-rest/src/test/java/org/cadenzaflow/bpm/engine/rest/security/auth/impl/CompositeAuthenticationProviderTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/cadenzaflow/bpm/engine/rest/security/auth/impl/CompositeAuthenticationProviderTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cadenzaflow.bpm.engine.rest.security.auth.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.cadenzaflow.bpm.engine.IdentityService;
+import org.cadenzaflow.bpm.engine.ProcessEngine;
+import org.cadenzaflow.bpm.engine.rest.security.auth.AuthenticationResult;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+/**
+ * Unit tests for {@link CompositeAuthenticationProvider}: scheme dispatch
+ * (Bearer → Keycloak, Basic/none → HTTP Basic) and the dual
+ * {@code WWW-Authenticate} challenge. Uses an in-memory JWKS — no network.
+ */
+public class CompositeAuthenticationProviderTest {
+
+  protected static final String ISSUER = "https://idp.example.com/realms/cadenzaflow";
+  protected static final String AUDIENCE = "cadenzaflow-rest";
+
+  protected static RSAKey signingKey;
+
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    signingKey = new RSAKeyGenerator(2048).keyID("primary").generate();
+  }
+
+  protected CompositeAuthenticationProvider provider() throws Exception {
+    KeycloakBearerTokenAuthenticationProvider bearerProvider = new KeycloakBearerTokenAuthenticationProvider() {
+      @Override
+      protected BearerTokenValidator createValidator(KeycloakProviderConfig config) {
+        return new BearerTokenValidator(config,
+            new ImmutableJWKSet<SecurityContext>(new JWKSet(signingKey.toPublicJWK())));
+      }
+    };
+
+    CompositeAuthenticationProvider provider =
+        new CompositeAuthenticationProvider(bearerProvider, new HttpBasicAuthenticationProvider());
+
+    Map<String, String> params = new HashMap<String, String>();
+    params.put(KeycloakProviderConfig.PARAM_ISSUER_URI, ISSUER);
+    params.put(KeycloakProviderConfig.PARAM_AUDIENCE, AUDIENCE);
+    provider.configure(params);
+    return provider;
+  }
+
+  protected HttpServletRequest request(String authorizationHeader) {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getHeader("Authorization")).thenReturn(authorizationHeader);
+    return request;
+  }
+
+  @Test
+  public void bearerRequestIsRoutedToKeycloakProvider() throws Exception {
+    JWTClaimsSet claims = new JWTClaimsSet.Builder()
+        .issuer(ISSUER)
+        .audience(AUDIENCE)
+        .expirationTime(new Date(System.currentTimeMillis() + 300000L))
+        .claim("preferred_username", "kermit")
+        .build();
+    SignedJWT jwt = new SignedJWT(
+        new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(signingKey.getKeyID()).build(), claims);
+    jwt.sign(new RSASSASigner(signingKey));
+
+    AuthenticationResult result = provider()
+        .extractAuthenticatedUser(request("Bearer " + jwt.serialize()), mock(ProcessEngine.class));
+
+    assertThat(result.isAuthenticated()).isTrue();
+    assertThat(result.getAuthenticatedUser()).isEqualTo("kermit");
+  }
+
+  @Test
+  public void basicRequestIsRoutedToBasicProvider() throws Exception {
+    ProcessEngine engine = mock(ProcessEngine.class);
+    IdentityService identityService = mock(IdentityService.class);
+    when(engine.getIdentityService()).thenReturn(identityService);
+    when(identityService.checkPassword("kermit", "kermit")).thenReturn(true);
+
+    // "kermit:kermit" base64
+    AuthenticationResult result = provider()
+        .extractAuthenticatedUser(request("Basic a2VybWl0Omtlcm1pdA=="), engine);
+
+    assertThat(result.isAuthenticated()).isTrue();
+    assertThat(result.getAuthenticatedUser()).isEqualTo("kermit");
+  }
+
+  @Test
+  public void missingHeaderTakesBasicPathAndIsUnsuccessful() throws Exception {
+    AuthenticationResult result = provider().extractAuthenticatedUser(request(null), mock(ProcessEngine.class));
+
+    assertThat(result.isAuthenticated()).isFalse();
+  }
+
+  @Test
+  public void challengeAdvertisesBothSchemesWithoutOverwriting() throws Exception {
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    ProcessEngine engine = mock(ProcessEngine.class);
+    when(engine.getName()).thenReturn("default");
+
+    provider().augmentResponseByAuthenticationChallenge(response, engine);
+
+    // both schemes via addHeader — setHeader would overwrite (Phase 4 review FINDING-001)
+    verify(response).addHeader("WWW-Authenticate", "Bearer realm=\"default\"");
+    verify(response).addHeader("WWW-Authenticate", "Basic realm=\"default\"");
+    verifyNoMoreInteractions(response);
+  }
+}

--- a/engine-rest/engine-rest/src/test/java/org/cadenzaflow/bpm/engine/rest/security/auth/impl/KeycloakBearerTokenAuthenticationProviderContainerIT.java
+++ b/engine-rest/engine-rest/src/test/java/org/cadenzaflow/bpm/engine/rest/security/auth/impl/KeycloakBearerTokenAuthenticationProviderContainerIT.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cadenzaflow.bpm.engine.rest.security.auth.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.cadenzaflow.bpm.engine.ProcessEngine;
+import org.cadenzaflow.bpm.engine.rest.security.auth.AuthenticationResult;
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * <p>
+ * Container integration test: validates the provider against a REAL Keycloak
+ * (Testcontainers) — covering everything the unit tests' in-memory JWKS cannot:
+ * the URL-based JWKS fetch/cache path, real token shapes from the
+ * {@code client_credentials} and {@code password} grants, and the real-world
+ * audience behavior (Keycloak access tokens typically carry
+ * {@code aud=account} and the client id only in {@code azp} — the reason the
+ * {@code audience-mode} configuration exists).
+ * </p>
+ *
+ * <p>
+ * NOT part of the default surefire run (IT suffix). Run explicitly:
+ * {@code mvn -pl engine-rest/engine-rest test
+ * -Dtest=KeycloakBearerTokenAuthenticationProviderContainerIT}. Requires
+ * Docker; skips (JUnit assume) when unavailable.
+ * </p>
+ *
+ * <p>
+ * Modern Docker engines (25+) raised the minimum API version above
+ * docker-java's non-negotiated default (1.32) — without help, Testcontainers'
+ * detection fails with an empty HTTP 400 on {@code /info}. docker-java honors
+ * the {@code api.version} SYSTEM property (not docker CLI's
+ * {@code DOCKER_API_VERSION} env var), so this class pins it in a static
+ * initializer before any Testcontainers class loads.
+ * </p>
+ */
+public class KeycloakBearerTokenAuthenticationProviderContainerIT {
+
+  static {
+    // Docker 25+: daemon min API > docker-java's non-negotiated 1.32 default.
+    // 1.44 is supported by every 2024+ engine; override externally if needed.
+    if (System.getProperty("api.version") == null) {
+      System.setProperty("api.version", "1.44");
+    }
+  }
+
+  protected static final String REALM = "cadenzaflow";
+  protected static final String CLIENT_ID = "cadenzaflow-rest";
+  protected static final String CLIENT_SECRET = "test-secret";
+  protected static final DockerImageName KEYCLOAK_IMAGE = DockerImageName.parse("quay.io/keycloak/keycloak:26.0");
+
+  protected static GenericContainer<?> keycloak;
+  protected static String issuer;
+
+  @BeforeClass
+  public static void startKeycloak() {
+    Assume.assumeTrue("Docker is not available - skipping Keycloak container IT",
+        DockerClientFactory.instance().isDockerAvailable());
+
+    keycloak = new GenericContainer<>(KEYCLOAK_IMAGE)
+        .withEnv("KC_BOOTSTRAP_ADMIN_USERNAME", "admin")
+        .withEnv("KC_BOOTSTRAP_ADMIN_PASSWORD", "admin")
+        .withCopyFileToContainer(
+            MountableFile.forClasspathResource("keycloak/cadenzaflow-realm.json"),
+            "/opt/keycloak/data/import/cadenzaflow-realm.json")
+        .withCommand("start-dev", "--import-realm")
+        .withExposedPorts(8080)
+        .waitingFor(Wait.forHttp("/realms/" + REALM).forPort(8080)
+            .withStartupTimeout(Duration.ofMinutes(3)));
+    keycloak.start();
+
+    issuer = "http://" + keycloak.getHost() + ":" + keycloak.getMappedPort(8080) + "/realms/" + REALM;
+  }
+
+  @AfterClass
+  public static void stopKeycloak() {
+    if (keycloak != null) {
+      keycloak.stop();
+    }
+  }
+
+  // helpers
+
+  protected static String fetchToken(String form) throws Exception {
+    // Plain blocking HttpURLConnection on purpose: java.net.http.HttpClient's
+    // internal NIO Selector cannot open its loopback pipe on this host (the
+    // same mechanism nimbus's JWKS retriever avoids, for the same reason).
+    HttpURLConnection connection = (HttpURLConnection) new URL(issuer + "/protocol/openid-connect/token")
+        .openConnection();
+    connection.setRequestMethod("POST");
+    connection.setDoOutput(true);
+    connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+    OutputStream out = connection.getOutputStream();
+    try {
+      out.write(form.getBytes(StandardCharsets.UTF_8));
+    } finally {
+      out.close();
+    }
+
+    int status = connection.getResponseCode();
+    InputStream in = status >= 400 ? connection.getErrorStream() : connection.getInputStream();
+    String body = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    assertThat(status).as("token endpoint response: %s", body).isEqualTo(200);
+    return new ObjectMapper().readTree(body).get("access_token").asText();
+  }
+
+  protected static String clientCredentialsToken() throws Exception {
+    return fetchToken("grant_type=client_credentials&client_id=" + CLIENT_ID + "&client_secret=" + CLIENT_SECRET);
+  }
+
+  protected static String passwordToken() throws Exception {
+    return fetchToken("grant_type=password&client_id=" + CLIENT_ID + "&client_secret=" + CLIENT_SECRET
+        + "&username=kermit&password=kermit");
+  }
+
+  /** Real provider: URL-based JWKS (derived from the issuer, Keycloak convention). */
+  protected KeycloakBearerTokenAuthenticationProvider provider(String audienceMode) throws Exception {
+    Map<String, String> params = new HashMap<String, String>();
+    params.put(KeycloakProviderConfig.PARAM_ISSUER_URI, issuer);
+    params.put(KeycloakProviderConfig.PARAM_AUDIENCE, CLIENT_ID);
+    params.put(KeycloakProviderConfig.PARAM_AUDIENCE_MODE, audienceMode);
+
+    KeycloakBearerTokenAuthenticationProvider provider = new KeycloakBearerTokenAuthenticationProvider();
+    provider.configure(params);
+    return provider;
+  }
+
+  protected AuthenticationResult authenticate(KeycloakBearerTokenAuthenticationProvider provider, String token) {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+    return provider.extractAuthenticatedUser(request, mock(ProcessEngine.class));
+  }
+
+  // tests
+
+  @Test
+  public void clientCredentialsTokenAuthenticatesInAzpMode() throws Exception {
+    AuthenticationResult result = authenticate(provider("azp"), clientCredentialsToken());
+
+    assertThat(result.isAuthenticated()).isTrue();
+    // Keycloak convention: the service account user of the client
+    assertThat(result.getAuthenticatedUser()).isEqualTo("service-account-" + CLIENT_ID);
+    assertThat(result.getGroups()).isNull(); // groups resolve via IdentityService, never from the token
+  }
+
+  @Test
+  public void clientCredentialsTokenFailsInDefaultAudMode() throws Exception {
+    // Real Keycloak access tokens carry aud=account (not our client id) — the
+    // documented reason audience-mode azp|any exists. If this ever starts
+    // passing, Keycloak changed its default aud contents; re-evaluate D-4/§4.1.
+    AuthenticationResult result = authenticate(provider("aud"), clientCredentialsToken());
+
+    assertThat(result.isAuthenticated()).isFalse();
+  }
+
+  @Test
+  public void passwordGrantTokenAuthenticatesUser() throws Exception {
+    AuthenticationResult result = authenticate(provider("any"), passwordToken());
+
+    assertThat(result.isAuthenticated()).isTrue();
+    assertThat(result.getAuthenticatedUser()).isEqualTo("kermit");
+  }
+
+  @Test
+  public void tamperedTokenIsRejected() throws Exception {
+    String token = passwordToken();
+    // flip a character in the payload part
+    int dot = token.indexOf('.') + 5;
+    char original = token.charAt(dot);
+    String tampered = token.substring(0, dot) + (original == 'A' ? 'B' : 'A') + token.substring(dot + 1);
+
+    AuthenticationResult result = authenticate(provider("any"), tampered);
+
+    assertThat(result.isAuthenticated()).isFalse();
+  }
+
+  @Test
+  public void tokenFromAnotherRealmIsRejected() throws Exception {
+    // provider configured for a different issuer must reject our realm's token
+    Map<String, String> params = new HashMap<String, String>();
+    params.put(KeycloakProviderConfig.PARAM_ISSUER_URI, issuer + "-other");
+    params.put(KeycloakProviderConfig.PARAM_JWKS_URI, issuer + "/protocol/openid-connect/certs");
+    params.put(KeycloakProviderConfig.PARAM_AUDIENCE, CLIENT_ID);
+    params.put(KeycloakProviderConfig.PARAM_AUDIENCE_MODE, "any");
+    KeycloakBearerTokenAuthenticationProvider wrongIssuerProvider = new KeycloakBearerTokenAuthenticationProvider();
+    wrongIssuerProvider.configure(params);
+
+    AuthenticationResult result = authenticate(wrongIssuerProvider, passwordToken());
+
+    assertThat(result.isAuthenticated()).isFalse();
+  }
+}

--- a/engine-rest/engine-rest/src/test/java/org/cadenzaflow/bpm/engine/rest/security/auth/impl/KeycloakBearerTokenAuthenticationProviderTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/cadenzaflow/bpm/engine/rest/security/auth/impl/KeycloakBearerTokenAuthenticationProviderTest.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cadenzaflow.bpm.engine.rest.security.auth.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.cadenzaflow.bpm.engine.ProcessEngine;
+import org.cadenzaflow.bpm.engine.rest.security.auth.AuthenticationResult;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+/**
+ * Unit tests for {@link KeycloakBearerTokenAuthenticationProvider}: token
+ * validation against a locally generated RSA key exposed as an in-memory JWKS
+ * ({@link ImmutableJWKSet}) — no network, no container. The URL-backed JWKS
+ * fetch/cache path is covered by the Keycloak container IT.
+ */
+public class KeycloakBearerTokenAuthenticationProviderTest {
+
+  protected static final String ISSUER = "https://idp.example.com/realms/cadenzaflow";
+  protected static final String AUDIENCE = "cadenzaflow-rest";
+
+  protected static RSAKey signingKey;    // published in the JWKS
+  protected static RSAKey rogueKey;      // same kid, different key → bad signature
+  protected static RSAKey unknownKidKey; // kid not in the JWKS
+
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    signingKey = new RSAKeyGenerator(2048).keyID("primary").generate();
+    rogueKey = new RSAKeyGenerator(2048).keyID("primary").generate();
+    unknownKidKey = new RSAKeyGenerator(2048).keyID("unknown").generate();
+  }
+
+  // helpers
+
+  /** Provider whose validator uses the in-memory JWKS instead of a URL fetch. */
+  protected static KeycloakBearerTokenAuthenticationProvider inMemoryJwksProvider() {
+    return new KeycloakBearerTokenAuthenticationProvider() {
+      @Override
+      protected BearerTokenValidator createValidator(KeycloakProviderConfig config) {
+        return new BearerTokenValidator(config,
+            new ImmutableJWKSet<SecurityContext>(new JWKSet(signingKey.toPublicJWK())));
+      }
+    };
+  }
+
+  protected KeycloakBearerTokenAuthenticationProvider provider() throws Exception {
+    return provider(new HashMap<String, String>());
+  }
+
+  protected KeycloakBearerTokenAuthenticationProvider provider(Map<String, String> extraParams) throws Exception {
+    Map<String, String> params = new HashMap<String, String>();
+    params.put(KeycloakProviderConfig.PARAM_ISSUER_URI, ISSUER);
+    params.put(KeycloakProviderConfig.PARAM_AUDIENCE, AUDIENCE);
+    params.putAll(extraParams);
+
+    KeycloakBearerTokenAuthenticationProvider provider = inMemoryJwksProvider();
+    provider.configure(params);
+    return provider;
+  }
+
+  protected JWTClaimsSet.Builder defaultClaims() {
+    return new JWTClaimsSet.Builder()
+        .issuer(ISSUER)
+        .audience(AUDIENCE)
+        .expirationTime(new Date(System.currentTimeMillis() + 300000L))
+        .claim("preferred_username", "kermit");
+  }
+
+  protected String sign(RSAKey key, JWTClaimsSet claims) throws Exception {
+    SignedJWT jwt = new SignedJWT(
+        new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(key.getKeyID()).build(),
+        claims);
+    jwt.sign(new RSASSASigner(key));
+    return jwt.serialize();
+  }
+
+  protected HttpServletRequest request(String authorizationHeader) {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getHeader("Authorization")).thenReturn(authorizationHeader);
+    return request;
+  }
+
+  protected AuthenticationResult authenticate(KeycloakBearerTokenAuthenticationProvider provider, String token) {
+    return provider.extractAuthenticatedUser(request("Bearer " + token), mock(ProcessEngine.class));
+  }
+
+  // happy path + username claims
+
+  @Test
+  public void validTokenAuthenticatesPreferredUsername() throws Exception {
+    AuthenticationResult result = authenticate(provider(), sign(signingKey, defaultClaims().build()));
+
+    assertThat(result.isAuthenticated()).isTrue();
+    assertThat(result.getAuthenticatedUser()).isEqualTo("kermit");
+    // groups deliberately NOT taken from the token — the filter resolves them via the IdentityService
+    assertThat(result.getGroups()).isNull();
+    assertThat(result.getTenants()).isNull();
+  }
+
+  @Test
+  public void usernameFallsBackToSubClaim() throws Exception {
+    JWTClaimsSet claims = new JWTClaimsSet.Builder()
+        .issuer(ISSUER)
+        .audience(AUDIENCE)
+        .expirationTime(new Date(System.currentTimeMillis() + 300000L))
+        .subject("service-account-worker")
+        .build();
+
+    AuthenticationResult result = authenticate(provider(), sign(signingKey, claims));
+
+    assertThat(result.isAuthenticated()).isTrue();
+    assertThat(result.getAuthenticatedUser()).isEqualTo("service-account-worker");
+  }
+
+  @Test
+  public void missingUsernameAndSubjectIsUnsuccessful() throws Exception {
+    JWTClaimsSet claims = new JWTClaimsSet.Builder()
+        .issuer(ISSUER)
+        .audience(AUDIENCE)
+        .expirationTime(new Date(System.currentTimeMillis() + 300000L))
+        .build();
+
+    assertThat(authenticate(provider(), sign(signingKey, claims)).isAuthenticated()).isFalse();
+  }
+
+  // expiry / nbf / clock skew
+
+  @Test
+  public void expiredTokenBeyondSkewIsUnsuccessful() throws Exception {
+    JWTClaimsSet claims = defaultClaims()
+        .expirationTime(new Date(System.currentTimeMillis() - 600000L))
+        .build();
+
+    assertThat(authenticate(provider(), sign(signingKey, claims)).isAuthenticated()).isFalse();
+  }
+
+  @Test
+  public void expiredTokenWithinSkewIsAccepted() throws Exception {
+    JWTClaimsSet claims = defaultClaims()
+        .expirationTime(new Date(System.currentTimeMillis() - 30000L)) // 30 s ago, default skew 60 s
+        .build();
+
+    assertThat(authenticate(provider(), sign(signingKey, claims)).isAuthenticated()).isTrue();
+  }
+
+  @Test
+  public void notYetValidTokenBeyondSkewIsUnsuccessful() throws Exception {
+    JWTClaimsSet claims = defaultClaims()
+        .notBeforeTime(new Date(System.currentTimeMillis() + 600000L))
+        .build();
+
+    assertThat(authenticate(provider(), sign(signingKey, claims)).isAuthenticated()).isFalse();
+  }
+
+  // issuer / audience
+
+  @Test
+  public void wrongIssuerIsUnsuccessful() throws Exception {
+    JWTClaimsSet claims = defaultClaims().issuer("https://evil.example.com/realms/other").build();
+
+    assertThat(authenticate(provider(), sign(signingKey, claims)).isAuthenticated()).isFalse();
+  }
+
+  @Test
+  public void wrongAudienceIsUnsuccessful() throws Exception {
+    JWTClaimsSet claims = defaultClaims().audience("some-other-client").build();
+
+    assertThat(authenticate(provider(), sign(signingKey, claims)).isAuthenticated()).isFalse();
+  }
+
+  @Test
+  public void azpOnlyTokenFailsInDefaultAudMode() throws Exception {
+    // Keycloak client_credentials tokens often have azp but no aud
+    JWTClaimsSet claims = new JWTClaimsSet.Builder()
+        .issuer(ISSUER)
+        .claim("azp", AUDIENCE)
+        .expirationTime(new Date(System.currentTimeMillis() + 300000L))
+        .claim("preferred_username", "kermit")
+        .build();
+
+    assertThat(authenticate(provider(), sign(signingKey, claims)).isAuthenticated()).isFalse();
+  }
+
+  @Test
+  public void azpOnlyTokenPassesInAzpMode() throws Exception {
+    Map<String, String> extra = new HashMap<String, String>();
+    extra.put(KeycloakProviderConfig.PARAM_AUDIENCE_MODE, "azp");
+
+    JWTClaimsSet claims = new JWTClaimsSet.Builder()
+        .issuer(ISSUER)
+        .claim("azp", AUDIENCE)
+        .expirationTime(new Date(System.currentTimeMillis() + 300000L))
+        .claim("preferred_username", "kermit")
+        .build();
+
+    assertThat(authenticate(provider(extra), sign(signingKey, claims)).isAuthenticated()).isTrue();
+  }
+
+  @Test
+  public void anyModeAcceptsAudOrAzp() throws Exception {
+    Map<String, String> extra = new HashMap<String, String>();
+    extra.put(KeycloakProviderConfig.PARAM_AUDIENCE_MODE, "any");
+
+    JWTClaimsSet azpOnly = new JWTClaimsSet.Builder()
+        .issuer(ISSUER)
+        .claim("azp", AUDIENCE)
+        .expirationTime(new Date(System.currentTimeMillis() + 300000L))
+        .claim("preferred_username", "kermit")
+        .build();
+    assertThat(authenticate(provider(extra), sign(signingKey, azpOnly)).isAuthenticated()).isTrue();
+
+    JWTClaimsSet audOnly = defaultClaims().build();
+    assertThat(authenticate(provider(extra), sign(signingKey, audOnly)).isAuthenticated()).isTrue();
+
+    JWTClaimsSet neither = new JWTClaimsSet.Builder()
+        .issuer(ISSUER)
+        .claim("azp", "some-other-client")
+        .audience("some-other-client")
+        .expirationTime(new Date(System.currentTimeMillis() + 300000L))
+        .claim("preferred_username", "kermit")
+        .build();
+    assertThat(authenticate(provider(extra), sign(signingKey, neither)).isAuthenticated()).isFalse();
+  }
+
+  // signature / key / algorithm
+
+  @Test
+  public void badSignatureIsUnsuccessful() throws Exception {
+    // same kid as the published key, but a different private key
+    assertThat(authenticate(provider(), sign(rogueKey, defaultClaims().build())).isAuthenticated()).isFalse();
+  }
+
+  @Test
+  public void unknownKidIsUnsuccessful() throws Exception {
+    assertThat(authenticate(provider(), sign(unknownKidKey, defaultClaims().build())).isAuthenticated()).isFalse();
+  }
+
+  @Test
+  public void hmacSignedTokenIsRejected() throws Exception {
+    SignedJWT jwt = new SignedJWT(
+        new JWSHeader.Builder(JWSAlgorithm.HS256).keyID("primary").build(),
+        defaultClaims().build());
+    jwt.sign(new MACSigner("01234567890123456789012345678901".getBytes(StandardCharsets.UTF_8)));
+
+    assertThat(authenticate(provider(), jwt.serialize()).isAuthenticated()).isFalse();
+  }
+
+  // header handling
+
+  @Test
+  public void malformedTokenIsUnsuccessful() throws Exception {
+    assertThat(authenticate(provider(), "not.a.jwt").isAuthenticated()).isFalse();
+  }
+
+  @Test
+  public void missingHeaderIsUnsuccessful() throws Exception {
+    AuthenticationResult result = provider().extractAuthenticatedUser(request(null), mock(ProcessEngine.class));
+    assertThat(result.isAuthenticated()).isFalse();
+  }
+
+  @Test
+  public void nonBearerHeaderIsUnsuccessful() throws Exception {
+    AuthenticationResult result = provider()
+        .extractAuthenticatedUser(request("Basic a2VybWl0Omtlcm1pdA=="), mock(ProcessEngine.class));
+    assertThat(result.isAuthenticated()).isFalse();
+  }
+
+  @Test
+  public void emptyBearerTokenIsUnsuccessful() throws Exception {
+    AuthenticationResult result = provider().extractAuthenticatedUser(request("Bearer    "), mock(ProcessEngine.class));
+    assertThat(result.isAuthenticated()).isFalse();
+  }
+
+  @Test
+  public void unconfiguredProviderIsUnsuccessfulInsteadOfFailing() {
+    KeycloakBearerTokenAuthenticationProvider unconfigured = new KeycloakBearerTokenAuthenticationProvider();
+    AuthenticationResult result = unconfigured
+        .extractAuthenticatedUser(request("Bearer whatever"), mock(ProcessEngine.class));
+    assertThat(result.isAuthenticated()).isFalse();
+  }
+
+  @Test
+  public void misconfigurationFailsAtConfigureTime() {
+    KeycloakBearerTokenAuthenticationProvider provider = inMemoryJwksProvider();
+    Map<String, String> params = new HashMap<String, String>(); // issuer + audience missing
+
+    try {
+      provider.configure(params);
+      throw new AssertionError("expected ServletException");
+    } catch (ServletException expected) {
+      // deploy-time fail-fast
+    }
+  }
+
+  // challenge
+
+  @Test
+  public void challengeIsRealmOnlyBearer() throws Exception {
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    ProcessEngine engine = mock(ProcessEngine.class);
+    when(engine.getName()).thenReturn("default");
+
+    provider().augmentResponseByAuthenticationChallenge(response, engine);
+
+    // realm-only, no error attribute (RFC 6750 §3 — cannot distinguish missing vs invalid credentials)
+    verify(response).setHeader("WWW-Authenticate", "Bearer realm=\"default\"");
+  }
+}

--- a/engine-rest/engine-rest/src/test/java/org/cadenzaflow/bpm/engine/rest/security/auth/impl/KeycloakProviderConfigTest.java
+++ b/engine-rest/engine-rest/src/test/java/org/cadenzaflow/bpm/engine/rest/security/auth/impl/KeycloakProviderConfigTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cadenzaflow.bpm.engine.rest.security.auth.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+
+import org.cadenzaflow.bpm.engine.rest.security.auth.impl.KeycloakProviderConfig.AudienceMode;
+import org.junit.Test;
+
+import com.nimbusds.jose.JWSAlgorithm;
+
+public class KeycloakProviderConfigTest {
+
+  protected Map<String, String> minimalParams() {
+    Map<String, String> params = new HashMap<String, String>();
+    params.put(KeycloakProviderConfig.PARAM_ISSUER_URI, "https://idp.example.com/realms/cadenzaflow");
+    params.put(KeycloakProviderConfig.PARAM_AUDIENCE, "cadenzaflow-rest");
+    return params;
+  }
+
+  @Test
+  public void minimalConfigurationAppliesDocumentedDefaults() throws Exception {
+    KeycloakProviderConfig config = KeycloakProviderConfig.fromInitParams(minimalParams());
+
+    assertThat(config.issuer()).isEqualTo("https://idp.example.com/realms/cadenzaflow");
+    assertThat(config.audience()).isEqualTo("cadenzaflow-rest");
+    assertThat(config.audienceMode()).isEqualTo(AudienceMode.AUD);
+    assertThat(config.usernameClaim()).isEqualTo("preferred_username");
+    assertThat(config.fallbackClaim()).isEqualTo("sub");
+    assertThat(config.expectedAlgs()).containsExactly(JWSAlgorithm.RS256);
+    assertThat(config.clockSkewSeconds()).isEqualTo(60);
+    assertThat(config.jwksCacheTtlMs()).isEqualTo(300000L);
+    assertThat(config.jwksCacheRefreshTimeoutMs()).isEqualTo(30000L);
+    assertThat(config.jwksMinIntervalMs()).isEqualTo(30000L);
+  }
+
+  @Test
+  public void jwksUriIsDerivedFromIssuerWithKeycloakConvention() throws Exception {
+    assertThat(KeycloakProviderConfig.fromInitParams(minimalParams()).jwksUri())
+        .isEqualTo("https://idp.example.com/realms/cadenzaflow/protocol/openid-connect/certs");
+  }
+
+  @Test
+  public void jwksUriDerivationHandlesTrailingSlash() throws Exception {
+    Map<String, String> params = minimalParams();
+    params.put(KeycloakProviderConfig.PARAM_ISSUER_URI, "https://idp.example.com/realms/cadenzaflow/");
+
+    assertThat(KeycloakProviderConfig.fromInitParams(params).jwksUri())
+        .isEqualTo("https://idp.example.com/realms/cadenzaflow/protocol/openid-connect/certs");
+  }
+
+  @Test
+  public void explicitJwksUriWins() throws Exception {
+    Map<String, String> params = minimalParams();
+    params.put(KeycloakProviderConfig.PARAM_JWKS_URI, "https://generic-idp.example.com/jwks.json");
+
+    assertThat(KeycloakProviderConfig.fromInitParams(params).jwksUri())
+        .isEqualTo("https://generic-idp.example.com/jwks.json");
+  }
+
+  @Test
+  public void missingIssuerFailsFast() {
+    Map<String, String> params = minimalParams();
+    params.remove(KeycloakProviderConfig.PARAM_ISSUER_URI);
+
+    assertThatThrownBy(() -> KeycloakProviderConfig.fromInitParams(params))
+        .isInstanceOf(ServletException.class)
+        .hasMessageContaining(KeycloakProviderConfig.PARAM_ISSUER_URI);
+  }
+
+  @Test
+  public void missingAudienceFailsFast() {
+    Map<String, String> params = minimalParams();
+    params.remove(KeycloakProviderConfig.PARAM_AUDIENCE);
+
+    assertThatThrownBy(() -> KeycloakProviderConfig.fromInitParams(params))
+        .isInstanceOf(ServletException.class)
+        .hasMessageContaining(KeycloakProviderConfig.PARAM_AUDIENCE);
+  }
+
+  @Test
+  public void blankRequiredParameterCountsAsMissing() {
+    Map<String, String> params = minimalParams();
+    params.put(KeycloakProviderConfig.PARAM_ISSUER_URI, "   ");
+
+    assertThatThrownBy(() -> KeycloakProviderConfig.fromInitParams(params))
+        .isInstanceOf(ServletException.class);
+  }
+
+  @Test
+  public void invalidAudienceModeFailsFast() {
+    Map<String, String> params = minimalParams();
+    params.put(KeycloakProviderConfig.PARAM_AUDIENCE_MODE, "bogus");
+
+    assertThatThrownBy(() -> KeycloakProviderConfig.fromInitParams(params))
+        .isInstanceOf(ServletException.class)
+        .hasMessageContaining("aud|azp|any");
+  }
+
+  @Test
+  public void audienceModeParsingIsCaseInsensitive() throws Exception {
+    Map<String, String> params = minimalParams();
+    params.put(KeycloakProviderConfig.PARAM_AUDIENCE_MODE, "AZP");
+
+    assertThat(KeycloakProviderConfig.fromInitParams(params).audienceMode()).isEqualTo(AudienceMode.AZP);
+  }
+
+  @Test
+  public void allowedAlgorithmsParsesCommaSeparatedList() throws Exception {
+    Map<String, String> params = minimalParams();
+    params.put(KeycloakProviderConfig.PARAM_ALLOWED_ALGORITHMS, "RS256, ES256");
+
+    assertThat(KeycloakProviderConfig.fromInitParams(params).expectedAlgs())
+        .containsExactlyInAnyOrder(JWSAlgorithm.RS256, JWSAlgorithm.ES256);
+  }
+
+  @Test
+  public void negativeNumericParameterFailsFast() {
+    Map<String, String> params = minimalParams();
+    params.put(KeycloakProviderConfig.PARAM_CLOCK_SKEW_SECONDS, "-5");
+
+    assertThatThrownBy(() -> KeycloakProviderConfig.fromInitParams(params))
+        .isInstanceOf(ServletException.class)
+        .hasMessageContaining(KeycloakProviderConfig.PARAM_CLOCK_SKEW_SECONDS);
+  }
+
+  @Test
+  public void nonNumericParameterFailsFast() {
+    Map<String, String> params = minimalParams();
+    params.put(KeycloakProviderConfig.PARAM_JWKS_CACHE_TTL_MS, "five minutes");
+
+    assertThatThrownBy(() -> KeycloakProviderConfig.fromInitParams(params))
+        .isInstanceOf(ServletException.class)
+        .hasMessageContaining(KeycloakProviderConfig.PARAM_JWKS_CACHE_TTL_MS);
+  }
+
+  @Test
+  public void unknownParametersAreIgnored() throws Exception {
+    Map<String, String> params = minimalParams();
+    params.put("some-unrelated-filter-param", "value");
+
+    assertThat(KeycloakProviderConfig.fromInitParams(params)).isNotNull();
+  }
+}

--- a/engine-rest/engine-rest/src/test/resources/keycloak/cadenzaflow-realm.json
+++ b/engine-rest/engine-rest/src/test/resources/keycloak/cadenzaflow-realm.json
@@ -1,0 +1,32 @@
+{
+  "realm": "cadenzaflow",
+  "enabled": true,
+  "clients": [
+    {
+      "clientId": "cadenzaflow-rest",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "test-secret",
+      "serviceAccountsEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "standardFlowEnabled": false
+    }
+  ],
+  "users": [
+    {
+      "username": "kermit",
+      "enabled": true,
+      "email": "kermit@example.com",
+      "firstName": "Kermit",
+      "lastName": "Frog",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "kermit",
+          "temporary": false
+        }
+      ]
+    }
+  ]
+}

--- a/internal-dependencies/pom.xml
+++ b/internal-dependencies/pom.xml
@@ -29,6 +29,12 @@
         <version>${version.gson}</version>
       </dependency>
       <dependency>
+        <!-- JWT validation for engine-rest OIDC Bearer authentication; version aligned with the pin already shipped in distro/run -->
+        <groupId>com.nimbusds</groupId>
+        <artifactId>nimbus-jose-jwt</artifactId>
+        <version>9.37.4</version>
+      </dependency>
+      <dependency>
         <groupId>cglib</groupId>
         <artifactId>cglib</artifactId>
         <version>2.2.2</version>


### PR DESCRIPTION
## What

Adds OIDC (Keycloak) Bearer-token authentication to `engine-rest` — **opt-in, additive, zero change to default behavior**. REST calls can now authenticate with `Authorization: Bearer <JWT>` obtained via `client_credentials` or `password`; HTTP Basic keeps working untouched (roadmap item 3, AS-IS Basic → TO-BE Basic+OIDC).

## Design (key decisions)

- **Offline validation, no per-request IdP round trip:** signature via cached JWKS, `iss`/`exp`/`nbf`(+skew)/audience enforced (nimbus-jose-jwt 9.37.4 — the same engine Spring Security uses internally, without the Spring dependency tree, so the one implementation runs in every distro: Tomcat, Run, starter, WildFly).
- **One identity source:** the provider returns only the user id; groups/tenants resolve through the engine `IdentityService` (never from token claims) — UI and REST authorization cannot diverge.
- **`audience-mode` aud|azp|any:** real Keycloak `client_credentials` tokens carry `aud=account` and the client id only in `azp` — confirmed empirically by the container IT.
- **Config via filter init-params** through a new optional `ConfigurableAuthenticationProvider` hook (the filter previously forwarded nothing to providers); misconfiguration fails at deploy time. All parameters are non-secret.
- **Mixed mode:** `CompositeAuthenticationProvider` dispatches Bearer→OIDC, Basic/none→today's path; dual realm-only `WWW-Authenticate` challenge (RFC 6750 §3).
- **Single source, both stacks:** written once against `javax`; `engine-rest-jakarta` regenerates via Eclipse Transformer (verified by smoke build — nimbus added to the jakarta module too).

## Verification

- **38 unit tests** (in-memory JWKS): claims/expiry/skew/issuer/audience matrix, signature/kid/alg rejection, header handling, composite dispatch + dual-challenge regression guard, config fail-fast.
- **Container IT 5/5** against real Keycloak 26 (Testcontainers, on-demand `-Dtest=...ContainerIT`): both grants end-to-end, URL JWKS path, tampered/wrong-issuer rejection, aud=account reality.
- Filter change is backward compatible: existing providers don't implement the hook, behavior byte-for-byte unchanged; with no OIDC config the distro web.xml stays exactly as before (commented example added alongside the existing commented Basic example).
- Design went through 5 adversarial review rounds (incl. two independent external-model reviews); all findings resolved.

## Files

- New: `ConfigurableAuthenticationProvider`, `KeycloakProviderConfig`, `KeycloakClaimsVerifier`, `BearerTokenValidator`, `KeycloakBearerTokenAuthenticationProvider`, `CompositeAuthenticationProvider` (+3 test classes, realm fixture)
- Changed: `ProcessEngineAuthenticationFilter` (init-param forwarding), `internal-dependencies` (nimbus 9.37.4, aligned with the pin already shipped in Run), module poms, README + Tomcat web.xml commented examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)