### PR TITLE
ci: fix Nexus deploy auth (401) + warn on inconsistent narrow deploys

### DIFF
--- a/.github/workflows/nexus-deploy.yml
+++ b/.github/workflows/nexus-deploy.yml
@@ -101,6 +101,11 @@ jobs:
           SKIP_TESTS: ${{ inputs.skip_tests || 'true' }}
           EXTRA_ARGS: ${{ inputs.maven_args || '' }}
           PROJECTS: ${{ inputs.projects || '' }}
+          # settings.xml resolves ${env.NEXUS_*} when MAVEN runs, so the
+          # secrets must be in THIS step's env - not only in the step that
+          # wrote the file. Without them the PUT goes out anonymous (401).
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
         run: |
           SKIP_FLAG=""
           if [ "${SKIP_TESTS}" = "true" ]; then
@@ -114,11 +119,28 @@ jobs:
           # two are mutually exclusive by design.
           PL="${PROJECTS:-!qa/integration-tests-engine,!qa/integration-tests-engine-jakarta,!qa/integration-tests-webapps,!qa/test-db-instance-migration,!qa/test-db-rolling-update,!qa/test-old-engine,!qa/large-data-tests,!qa/performance-tests-engine,!qa/tomcat-runtime,!qa/tomcat9-runtime,!qa/wildfly-runtime,!qa/wildfly26-runtime}"
 
+          # WARNING - narrow deploys publish INCONSISTENT releases.
+          # A -pl selection deploys only those modules; the parent POMs on
+          # Nexus keep whatever content they had. If a module's POM references
+          # a property that was added to the parent after the parents were
+          # published, the released artifact is unresolvable for everyone
+          # outside this repo. That is exactly what happened to the 1.2.0
+          # spring-boot-starter-4 family (${version.spring.framework7} is used
+          # by cadenzaflow-bpm-spring-boot-4-starter-root:1.2.0 but defined in
+          # no published parent). Prefer a full-reactor deploy for releases.
+          if [ -n "${PROJECTS}" ]; then
+            echo "::warning::Narrow deploy (-pl ${PROJECTS}): parent POMs are NOT redeployed. Verify the published POM chain resolves from a clean repository before announcing this release."
+          fi
+
+          # maven-deploy-plugin 3.x syntax is "id::url" (two segments). The
+          # legacy "id::default::url" form parses the server id as
+          # "id::default", so the settings.xml credentials never match and the
+          # upload goes out anonymous -> Nexus 401.
           ./mvnw deploy \
             --batch-mode \
             --fail-at-end \
             --threads 1C \
-            -DaltDeploymentRepository="${NEXUS_REPO_ID}::default::${NEXUS_URL}" \
+            -DaltDeploymentRepository="${NEXUS_REPO_ID}::${NEXUS_URL}" \
             ${SKIP_FLAG} \
             -pl "${PL}" \
             ${EXTRA_ARGS}


### PR DESCRIPTION
The Nexus deploy workflow could not publish at all. Both bugs were diagnosed empirically in `cadenzaflow-keycloak` (same workflow pattern), where these exact two fixes turned a persistent 401 into a successful release:

1. **`altDeploymentRepository` syntax** — `id::default::url` is the pre-3.x form. maven-deploy-plugin 3.x parses the server id as `cadenzaflow-nexus::default`, so the `settings.xml` credentials never match and the upload goes out anonymous → **Nexus 401**.
2. **Credential env scoping** — `NEXUS_USERNAME`/`NEXUS_PASSWORD` were only set on the step that *writes* `settings.xml`. Maven resolves `${env.*}` at run time, so the deploy step ran with empty credentials.

Additionally, a warning when `projects` (narrow `-pl`) is used. This is not hypothetical: it is how the published **1.2.0 `spring-boot-starter-4` family became unusable for every external consumer**. `cadenzaflow-bpm-spring-boot-4-starter-root:1.2.0` references `${version.spring.framework7}`, but that property exists in no published parent POM (it was added to `parent/pom.xml` *after* the parents were published, and a narrow deploy does not redeploy parents). Walking the published chain confirms it:

```
starter-test-4:1.2.0 -> 4-starter-root:1.2.0 (USES the property)
  -> database-settings:1.2.0 -> parent:1.2.0 -> root:1.2.0 -> release-parent:1.0.0
  (property defined in NONE of them)
```

Consumers see `Failed to read artifact descriptor ... spring-framework-bom:pom:${version.spring.framework7}`. A full-reactor 1.2.1 release fixes it (master already defines the property).

**Before this workflow can run, `NEXUS_USERNAME` / `NEXUS_PASSWORD` must be added to this repository's secrets** — they are currently absent here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)