### PR TITLE
ci(release): fix Nexus auth in CADENZAFLOW_RELEASE (prerequisite for 1.2.1)

### DIFF
--- a/.github/workflows/CADENZAFLOW_RELEASE.yml
+++ b/.github/workflows/CADENZAFLOW_RELEASE.yml
@@ -151,6 +151,12 @@ jobs:
             -DprocessAllModules -DgenerateBackupPoms=false
 
       - name: Build platform + distros (+ optional Nexus deploy)
+        env:
+          # settings.xml references ${env.NEXUS_*}, which Maven resolves when IT
+          # runs - so the secrets must be on THIS step, not only on the step
+          # that wrote the file. Otherwise the deploy goes out anonymous (401).
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
         run: |
           # Full build via the default 'distro' profile — engine, engine-spring-7,
           # webapps, rest, the -4 starters AND the tomcat/run distros. Same default
@@ -161,7 +167,10 @@ jobs:
           GOAL="install"; ALT=""
           if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event.inputs.deploy_to_nexus }}" = "true" ]; then
             GOAL="deploy"
-            ALT="-DaltDeploymentRepository=${NEXUS_REPO_ID}::default::${NEXUS_URL}"
+            # maven-deploy-plugin 3.x syntax is "id::url". The legacy
+            # "id::default::url" form parses the server id as "id::default", so
+            # the settings.xml credentials never match -> anonymous PUT -> 401.
+            ALT="-DaltDeploymentRepository=${NEXUS_REPO_ID}::${NEXUS_URL}"
           fi
           echo "Maven goal: clean ${GOAL}"
           ./mvnw clean "${GOAL}" \


### PR DESCRIPTION
`CADENZAFLOW_RELEASE.yml` carries the **same two defects** just fixed in `nexus-deploy.yml` (#19). Because this workflow has never been run, they would have appeared as a 401 *at the end of a multi-hour full-platform build*:

1. `altDeploymentRepository` used `id::default::url` — deploy-plugin 3.x parses the server id as `cadenzaflow-nexus::default`, credentials never match, upload goes out anonymous.
2. `NEXUS_USERNAME` / `NEXUS_PASSWORD` were set only on the step that writes `settings.xml`; Maven resolves `${env.*}` at run time, so the build/deploy step saw empty credentials.

Both fixes are proven: the identical pair turned a persistent 401 into a successful release in `cadenzaflow-keycloak`.

**Why now:** this is the prerequisite for cutting **1.2.1**, which republishes the `-4` starter POM chain that external consumers cannot resolve today (reproduction in #19). Our largest customer is blocked on it, and V1.3 LTS is due next month.

After merge, the release is triggered by pushing the tag `cadenzaflow-v1.2.1`; the canary in `cadenzaflow-keycloak` then proves consumption:

```bash
gh workflow run example-boot4.yml --repo cadenzaflow/cadenzaflow-keycloak -f version_cadenzaflow=1.2.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)