### PR TITLE
ci: skip Central publishing in the Nexus release path (1.2.1 blocker)

### DIFF
--- a/.github/workflows/CADENZAFLOW_RELEASE.yml
+++ b/.github/workflows/CADENZAFLOW_RELEASE.yml
@@ -139,6 +139,17 @@ jobs:
                 <username>${env.NEXUS_USERNAME}</username>
                 <password>${env.NEXUS_PASSWORD}</password>
               </server>
+              <!-- Inert stub. The release parent injects Sonatype's
+                   central-publishing plugin (execution id
+                   injected-central-publishing), which resolves a server with
+                   id `central` and NPEs when it is absent. We publish to the
+                   CadenzaFlow Nexus, not to Maven Central, and the plugin is
+                   skipped below - these credentials are never used. -->
+              <server>
+                <id>central</id>
+                <username>not-used-we-publish-to-nexus</username>
+                <password>not-used-we-publish-to-nexus</password>
+              </server>
             </servers>
           </settings>
           EOF
@@ -173,9 +184,14 @@ jobs:
             ALT="-DaltDeploymentRepository=${NEXUS_REPO_ID}::${NEXUS_URL}"
           fi
           echo "Maven goal: clean ${GOAL}"
+          # skipPublishing: the release parent injects Sonatype's Maven Central
+          # publishing plugin into `deploy`. This release goes to the
+          # CadenzaFlow Nexus; Central publication is a separate, not-yet-set-up
+          # process (namespace verification, signing keys).
           ./mvnw clean "${GOAL}" \
             --batch-mode --fail-at-end --threads 1C \
             -DskipTests -DskipITs \
+            -DskipPublishing=true \
             ${ALT} \
             -pl '!qa/integration-tests-engine,!qa/integration-tests-engine-jakarta,!qa/integration-tests-webapps,!qa/test-db-instance-migration,!qa/test-db-rolling-update,!qa/test-old-engine,!qa/large-data-tests,!qa/performance-tests-engine,!qa/tomcat-runtime,!qa/tomcat9-runtime,!qa/wildfly-runtime,!qa/wildfly26-runtime'
 

--- a/.github/workflows/nexus-deploy.yml
+++ b/.github/workflows/nexus-deploy.yml
@@ -89,6 +89,14 @@ jobs:
                 <username>${env.NEXUS_USERNAME}</username>
                 <password>${env.NEXUS_PASSWORD}</password>
               </server>
+              <!-- Inert stub - see CADENZAFLOW_RELEASE.yml: the release parent
+                   injects Sonatype's central-publishing plugin, which NPEs
+                   without a `central` server even though we skip it below. -->
+              <server>
+                <id>central</id>
+                <username>not-used-we-publish-to-nexus</username>
+                <password>not-used-we-publish-to-nexus</password>
+              </server>
             </servers>
           </settings>
           EOF
@@ -140,6 +148,7 @@ jobs:
             --batch-mode \
             --fail-at-end \
             --threads 1C \
+            -DskipPublishing=true \
             -DaltDeploymentRepository="${NEXUS_REPO_ID}::${NEXUS_URL}" \
             ${SKIP_FLAG} \
             -pl "${PL}" \


### PR DESCRIPTION
The first real `CADENZAFLOW_RELEASE` run ([30270134298](https://github.com/cadenzaflow/cadenzaflow-bpm-platform/actions/runs/30270134298)) failed two minutes in:

```
central-publishing-maven-plugin:0.4.0:publish (injected-central-publishing) on project cadenzaflow-root:
Unable to get publisher server properties for server id: central:
Cannot invoke "org.apache.maven.settings.Server.getUsername()" because "server" is null
```

The release parent injects Sonatype's Central publishing plugin into `deploy`. Our releases go to the **CadenzaFlow Nexus**; publishing to Maven Central is a separate process that is not set up yet (namespace verification, signing keys) — so the plugin has no business running here.

Fix: skip it via its documented user property, `-DskipPublishing=true` (name verified against the plugin's own descriptor, not guessed), plus an inert `central` server stub in `settings.xml` so the plugin cannot NPE during server lookup even if it is invoked.

Applied to `nexus-deploy.yml` as well — it would hit the same wall the first time it authenticates successfully.

Nothing was published by the failed run: no `1.2.1` artifacts on Nexus, no GitHub release. After merge the tag is re-cut and the release re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)