### PR TITLE
ci: purge stale cached parent POMs (1.2.1 blocker #2)

### DIFF
--- a/.github/workflows/CADENZAFLOW_RELEASE.yml
+++ b/.github/workflows/CADENZAFLOW_RELEASE.yml
@@ -154,6 +154,19 @@ jobs:
           </settings>
           EOF
 
+      - name: Purge cached CadenzaFlow artifacts (stale parent POMs poison the build)
+        run: |
+          # The Maven cache is restored across runs, and Maven never re-downloads
+          # a RELEASE artifact it already has. A parent POM that changed after
+          # publication therefore sticks around forever on the runner. That is
+          # not hypothetical: the cached cadenzaflow-release-parent:1.0.0 still
+          # activates Sonatype's Central publishing plugin, while the POM
+          # actually published on Nexus has it commented out ("disabled for
+          # Nexus-only deployment"). Our own artifacts are small - always take
+          # them fresh.
+          rm -rf ~/.m2/repository/org/cadenzaflow
+          echo "Purged ~/.m2/repository/org/cadenzaflow"
+
       - name: Align reactor version to the release tag
         run: |
           # No -P: the default activeByDefault 'distro' profile is the full reactor.
@@ -184,14 +197,17 @@ jobs:
             ALT="-DaltDeploymentRepository=${NEXUS_REPO_ID}::${NEXUS_URL}"
           fi
           echo "Maven goal: clean ${GOAL}"
-          # skipPublishing: the release parent injects Sonatype's Maven Central
-          # publishing plugin into `deploy`. This release goes to the
-          # CadenzaFlow Nexus; Central publication is a separate, not-yet-set-up
-          # process (namespace verification, signing keys).
+          # skip.central.release: belt and braces. The release parent published
+          # on Nexus has the Central publishing plugin commented out, but older
+          # variants of that POM bind the plugin's skip flag to this property.
+          # (Note: -DskipPublishing does NOT work - those variants configure the
+          # parameter in the POM, and POM configuration beats a CLI property.)
+          # This release goes to the CadenzaFlow Nexus; publishing to Maven
+          # Central is a separate process that is not set up yet.
           ./mvnw clean "${GOAL}" \
             --batch-mode --fail-at-end --threads 1C \
             -DskipTests -DskipITs \
-            -DskipPublishing=true \
+            -Dskip.central.release=true \
             ${ALT} \
             -pl '!qa/integration-tests-engine,!qa/integration-tests-engine-jakarta,!qa/integration-tests-webapps,!qa/test-db-instance-migration,!qa/test-db-rolling-update,!qa/test-old-engine,!qa/large-data-tests,!qa/performance-tests-engine,!qa/tomcat-runtime,!qa/tomcat9-runtime,!qa/wildfly-runtime,!qa/wildfly26-runtime'
 

--- a/.github/workflows/nexus-deploy.yml
+++ b/.github/workflows/nexus-deploy.yml
@@ -101,6 +101,14 @@ jobs:
           </settings>
           EOF
 
+      - name: Purge cached CadenzaFlow artifacts (stale parent POMs poison the build)
+        run: |
+          # See CADENZAFLOW_RELEASE.yml: Maven never re-downloads a RELEASE it
+          # already has, so a parent POM changed after publication survives in
+          # the runner cache forever. Ours are small - always take them fresh.
+          rm -rf ~/.m2/repository/org/cadenzaflow
+          echo "Purged ~/.m2/repository/org/cadenzaflow"
+
       - name: Show project version
         run: ./mvnw -q -N help:evaluate -Dexpression=project.version -DforceStdout && echo
 
@@ -148,7 +156,7 @@ jobs:
             --batch-mode \
             --fail-at-end \
             --threads 1C \
-            -DskipPublishing=true \
+            -Dskip.central.release=true \
             -DaltDeploymentRepository="${NEXUS_REPO_ID}::${NEXUS_URL}" \
             ${SKIP_FLAG} \
             -pl "${PL}" \


### PR DESCRIPTION
Root cause of the second failed 1.2.1 attempt ([30270690085](https://github.com/cadenzaflow/cadenzaflow-bpm-platform/actions/runs/30270690085)), where the build got 15 minutes in and then tried to upload to **Maven Central**.

Three different copies of `cadenzaflow-release-parent:1.0.0` are in circulation:

| Where | Central publishing plugin |
|---|---|
| published on Nexus (`cadenzaflow-release`) | **commented out** — *"disabled for Nexus-only deployment"* |
| older variants | active, skip flag bound to `${skip.central.release}` |
| the runner's Maven cache | **active** |

Maven never re-downloads a RELEASE artifact it already has, so the stale parent survives every cache restore and keeps injecting a publish-to-Central step into a Nexus-only release. Same family of bug as the `-4` starter chain: *what is published and what a build actually consumes have drifted apart.*

Fix: purge `~/.m2/repository/org/cadenzaflow` before building — our own artifacts are small, so always taking them fresh costs seconds and removes the whole class of problem.

Also replaces `-DskipPublishing=true` (added in #21) with `-Dskip.central.release=true`. The former **cannot** work: the POM variants configure that parameter explicitly, and POM configuration beats a CLI user property — which is exactly why the previous attempt still tried to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)