### PR TITLE
ci(release): build with 2 threads (1.2.1 blocker #3)

### DIFF
--- a/.github/workflows/CADENZAFLOW_RELEASE.yml
+++ b/.github/workflows/CADENZAFLOW_RELEASE.yml
@@ -204,8 +204,15 @@ jobs:
           # parameter in the POM, and POM configuration beats a CLI property.)
           # This release goes to the CadenzaFlow Nexus; publishing to Maven
           # Central is a separate process that is not set up yet.
+          # --threads 2, not 1C: at 1C (8 threads on this runner) the release
+          # build starves the self-hosted runner and it loses contact with
+          # GitHub ("The self-hosted runner lost communication with the
+          # server") about 30 minutes in. test.yml survives 1C because it does
+          # not assemble the distributions; this build does, concurrently.
+          # The job has a 240-minute budget, so trading parallelism for
+          # survivability is the right call here.
           ./mvnw clean "${GOAL}" \
-            --batch-mode --fail-at-end --threads 1C \
+            --batch-mode --fail-at-end --threads 2 \
             -DskipTests -DskipITs \
             -Dskip.central.release=true \
             ${ALT} \


### PR DESCRIPTION
Third 1.2.1 attempt ([30272573050](https://github.com/cadenzaflow/cadenzaflow-bpm-platform/actions/runs/30272573050)) died after ~31 minutes with **"The self-hosted runner lost communication with the server"** and produced no log — the runner was starved, not a Maven failure.

`test.yml` runs `--threads 1C` on the same runner fine, but it does not assemble the distributions. This build does, and `1C` means eight concurrent assemblies on an 8 vCPU / 30 GiB machine. The job has a 240-minute budget, so trading parallelism for survivability is right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)