### PR TITLE
ci(release): actually deploy to Nexus + verify (1.2.1 blocker #4)

### DIFF
--- a/.github/workflows/CADENZAFLOW_RELEASE.yml
+++ b/.github/workflows/CADENZAFLOW_RELEASE.yml
@@ -215,8 +215,26 @@ jobs:
             --batch-mode --fail-at-end --threads 2 \
             -DskipTests -DskipITs \
             -Dskip.central.release=true \
+            -Dmaven.deploy.skip=false \
             ${ALT} \
             -pl '!qa/integration-tests-engine,!qa/integration-tests-engine-jakarta,!qa/integration-tests-webapps,!qa/test-db-instance-migration,!qa/test-db-rolling-update,!qa/test-old-engine,!qa/large-data-tests,!qa/performance-tests-engine,!qa/tomcat-runtime,!qa/tomcat9-runtime,!qa/wildfly-runtime,!qa/wildfly26-runtime'
+
+      - name: Verify the artifacts really reached Nexus
+        if: ${{ github.event_name == 'push' || github.event.inputs.deploy_to_nexus == 'true' }}
+        run: |
+          # A release that deploys NOTHING must not report success. That is not
+          # theoretical: the central-publishing extension in the release parent
+          # replaces maven-deploy-plugin, so skipping the Central publish left
+          # `mvn deploy` doing nothing at all - BUILD SUCCESS, empty Nexus.
+          VERSION="${{ steps.v.outputs.VERSION }}"
+          URL="${NEXUS_URL}/org/cadenzaflow/bpm/cadenzaflow-engine/${VERSION}/cadenzaflow-engine-${VERSION}.pom"
+          CODE="$(curl -s -o /dev/null -w '%{http_code}' "$URL")"
+          echo "GET $URL -> $CODE"
+          if [ "$CODE" != "200" ]; then
+            echo "::error::Nothing was published: cadenzaflow-engine ${VERSION} is not on Nexus."
+            exit 1
+          fi
+          echo "Confirmed: cadenzaflow-engine ${VERSION} is on Nexus."
 
       - name: Collect distribution assets
         run: |


### PR DESCRIPTION
The fourth 1.2.1 attempt ([30275584428](https://github.com/cadenzaflow/cadenzaflow-bpm-platform/actions/runs/30275584428)) built the entire platform at 1.2.1, reported **BUILD SUCCESS** — and published **nothing**.

`maven-deploy-plugin` never ran. The deploy phase was handled by `central-publishing-maven-plugin (injected-central-publishing)`, which the release parent installs as a build **extension**; such an extension replaces the standard deploy. So once the Central publish is skipped (#22), `mvn deploy` becomes a complete no-op.

Two changes:
1. `-Dmaven.deploy.skip=false` counters the property the extension sets, so the standard deploy runs alongside the skipped Central publish.
2. A verification step: before creating the GitHub Release, confirm the engine artifact for this version is really on Nexus and fail loudly otherwise. *"Successful release, empty repository"* must never pass silently again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)