### PR TITLE
build: neutralise the inherited Central publishing extension (1.2.1 blocker #5)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,29 @@
           <excludedScopes>test</excludedScopes>
         </configuration>
       </plugin>
+      <!--
+        CadenzaFlow publishes to its own Nexus, not to Maven Central.
+
+        A release parent in our inherited chain installs Sonatype's Central
+        publishing plugin as a build EXTENSION. An extension of that plugin
+        REPLACES maven-deploy-plugin, so with the Central publish skipped the
+        deploy phase silently does nothing: the 1.2.1 release built the whole
+        platform, reported BUILD SUCCESS and published zero artifacts.
+
+        Declaring it here without the extension flag - the child declaration
+        wins over the inherited one - keeps the standard deploy in charge.
+        Publishing to Maven Central is a separate, not-yet-configured process
+        (namespace verification, signing keys); when it is set up it should be
+        enabled deliberately, in a profile, not inherited by accident.
+      -->
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <extensions>false</extensions>
+        <configuration>
+          <skipPublishing>true</skipPublishing>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Fifth 1.2.1 attempt ([30279180977](https://github.com/cadenzaflow/cadenzaflow-bpm-platform/actions/runs/30279180977)) was caught by the new verification step: **build succeeded, Nexus empty**.

Root cause: a release parent in our inherited chain installs Sonatype's Central publishing plugin as a build **extension**, and an extension of that plugin *replaces* `maven-deploy-plugin`. Once the Central publish is skipped (#22), the deploy phase does nothing at all. `-Dmaven.deploy.skip=false` (#24) did not help — the extension is wired into the build model, not gated by that property.

Fix: declare the plugin in our root POM **without** the extension flag; the child declaration wins over the inherited one, so the standard deploy stays in charge. Verified against the effective POM of the root **and** a child module (`engine`): `extensions=false`, `skipPublishing=true`.

Publishing to Maven Central stays possible later — but it should then be enabled deliberately in a profile, not inherited by accident (which is also what Cezmi's team will need when we take that on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)