### PR TITLE
build: keep the standard deploy switched on (1.2.1 blocker #6)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,38 @@
           <skipPublishing>true</skipPublishing>
         </configuration>
       </plugin>
+      <!--
+        ...and keep the standard deploy switched ON.
+
+        The release parent published on Nexus sets maven-deploy-plugin's
+        skip=false, but builds have been resolving an older copy of that POM
+        which sets skip=true at BOTH plugin and execution level - so `mvn
+        deploy` logged "Skipping artifact deployment" for all 142 modules and
+        published nothing while reporting success. POM configuration beats a
+        CLI property, which is why -Dmaven.deploy.skip=false had no effect.
+
+        Overriding both levels here makes the outcome independent of which
+        copy of the parent a given machine happens to resolve.
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>false</skip>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-deploy</id>
+            <phase>deploy</phase>
+            <goals>
+              <goal>deploy</goal>
+            </goals>
+            <configuration>
+              <skip>false</skip>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Sixth 1.2.1 attempt ([30281181477](https://github.com/cadenzaflow/cadenzaflow-bpm-platform/actions/runs/30281181477)): with the Central publishing extension neutralised (#25), `maven-deploy-plugin` finally ran — and logged **"Skipping artifact deployment"** for all 142 modules. Build green, Nexus empty, caught again by the verification step.

The release parent **published on Nexus** sets `maven-deploy-plugin` `skip=false`. But builds resolve an *older copy* of that POM, which sets `skip=true` at **both** plugin and execution level. POM configuration beats a CLI property — which is why `-Dmaven.deploy.skip=false` (#24) never did anything.

Overriding both levels in our own root POM makes the outcome independent of which copy of the parent a given machine resolves. Verified on the effective POM of the root **and** a child module (`engine`).

Worth a separate follow-up: track down and remove the stale `cadenzaflow-release-parent:1.0.0` copies so published and consumed POMs stop drifting apart — the same class of defect as the `-4` starter chain that started all of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)