### PR TITLE
ci: restore three-segment altDeploymentRepository (1.2.1 blocker #7)

### DIFF
--- a/.github/workflows/CADENZAFLOW_RELEASE.yml
+++ b/.github/workflows/CADENZAFLOW_RELEASE.yml
@@ -191,10 +191,13 @@ jobs:
           GOAL="install"; ALT=""
           if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event.inputs.deploy_to_nexus }}" = "true" ]; then
             GOAL="deploy"
-            # maven-deploy-plugin 3.x syntax is "id::url". The legacy
-            # "id::default::url" form parses the server id as "id::default", so
-            # the settings.xml credentials never match -> anonymous PUT -> 401.
-            ALT="-DaltDeploymentRepository=${NEXUS_REPO_ID}::${NEXUS_URL}"
+            # THREE segments, because this build pins maven-deploy-plugin
+            # 2.8.2, which requires "id::layout::url" and rejects anything
+            # else with "Invalid syntax for alternative repository".
+            # (Deploy-plugin 3.x wants the two-segment "id::url" instead - as
+            # used in cadenzaflow-keycloak. Check the plugin version before
+            # copying this line between repositories.)
+            ALT="-DaltDeploymentRepository=${NEXUS_REPO_ID}::default::${NEXUS_URL}"
           fi
           echo "Maven goal: clean ${GOAL}"
           # skip.central.release: belt and braces. The release parent published

--- a/.github/workflows/nexus-deploy.yml
+++ b/.github/workflows/nexus-deploy.yml
@@ -157,7 +157,7 @@ jobs:
             --fail-at-end \
             --threads 1C \
             -Dskip.central.release=true \
-            -DaltDeploymentRepository="${NEXUS_REPO_ID}::${NEXUS_URL}" \
+            -DaltDeploymentRepository="${NEXUS_REPO_ID}::default::${NEXUS_URL}" \
             ${SKIP_FLAG} \
             -pl "${PL}" \
             ${EXTRA_ARGS}


### PR DESCRIPTION
Seventh 1.2.1 attempt ([30282671013](https://github.com/cadenzaflow/cadenzaflow-bpm-platform/actions/runs/30282671013)) failed with:

```
Invalid syntax for alternative repository. Use "id::layout::url".
```

**My mistake.** This build pins **maven-deploy-plugin 2.8.2**, which requires the three-segment form — so `id::default::url` was correct all along. I generalised the two-segment `id::url` from `cadenzaflow-keycloak` (#19, #21), which runs deploy-plugin **3.x**, where two segments *is* the correct form. Same flag, opposite syntax, depending on a plugin version I failed to check here.

The other half of those PRs stands: the credentials genuinely had to be on the Maven step, not only on the settings.xml step. Comments now record the version dependency so this line is not copied between repositories again.

Progress: with #26, deploy is finally *attempting* to run — the earlier attempts skipped it silently for all 142 modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)