### PR TITLE
ci(release): remove the probe — disk theory disproved

### DIFF
--- a/.github/workflows/CADENZAFLOW_RELEASE.yml
+++ b/.github/workflows/CADENZAFLOW_RELEASE.yml
@@ -214,18 +214,11 @@ jobs:
             echo "Distributions are OFF: publishing Maven artifacts only."
           fi
 
-          # Disk/memory probe. The runner has twice been killed mid-build with
-          # "lost communication with the server" and no JVM OOM anywhere in the
-          # log, which points at ephemeral-storage eviction rather than RAM.
-          # Printing to THIS step's stdout (not a file) means the last sample
-          # before the pod dies is still visible in the streamed log.
-          ( while true; do
-              echo "PROBE $(date -u +%H:%M:%S) disk=$(df -h / | awk 'NR==2{print $3"/"$2" used, "$4" free"}') mem=$(free -g | awk '/Mem:/{print $3"/"$2"Gi used"}')"
-              sleep 30
-            done ) &
-          PROBE_PID=$!
-          trap 'kill $PROBE_PID 2>/dev/null || true' EXIT
-
+          # Measured 2026-07-27 with a temporary probe: at peak this build used
+          # 17 GB of the 50 GB disk and 11 GB of 30 GB RAM - so the runner
+          # deaths were NOT resource exhaustion. With a warm Maven cache the
+          # full build including both distributions finishes in under six
+          # minutes; the failures happened on long cold-cache runs.
           echo "Maven goal: clean ${GOAL}"
           # skip.central.release: belt and braces. The release parent published
           # on Nexus has the Central publishing plugin commented out, but older


### PR DESCRIPTION
**The measurement contradicts my hypothesis, so here it is plainly:** at peak this build used **17 GB of the 50 GB disk** and **11 GB of 30 GB RAM** ([run 30291298787](https://github.com/cadenzaflow/cadenzaflow-bpm-platform/actions/runs/30291298787)). The earlier *"runner lost communication"* deaths were **not** resource exhaustion — raising the runner's disk would have been money spent on the wrong thing.

Better news from the same run: with a warm Maven cache the full build **including both distributions** finished in **5:41** with BUILD SUCCESS. The step still reported failure (exit 127) because the probe's background loop outlived the script — my instrumentation, not the build. Removed.

Remaining question for another day: why long cold-cache runs lose the runner. Now that a full build takes minutes rather than half an hour, it is much less pressing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)