### PR TITLE
ci(release): never let the Central pass auto-publish

### DIFF
--- a/.github/workflows/CADENZAFLOW_RELEASE.yml
+++ b/.github/workflows/CADENZAFLOW_RELEASE.yml
@@ -399,6 +399,8 @@ jobs:
             -DskipTests -DskipITs \
             -Dgpg.passphrase="${GPG_PASSPHRASE}" \
             -Dgpg.args="--pinentry-mode=loopback --batch --yes" \
+            -DautoPublish=false \
+            -DwaitUntil=validated \
             -pl '!qa/integration-tests-engine,!qa/integration-tests-engine-jakarta,!qa/integration-tests-webapps,!qa/test-db-instance-migration,!qa/test-db-rolling-update,!qa/test-old-engine,!qa/large-data-tests,!qa/performance-tests-engine,!qa/tomcat-runtime,!qa/tomcat9-runtime,!qa/wildfly-runtime,!qa/wildfly26-runtime,!distro/tomcat,!distro/run'
 
       - name: Verify the version reached Maven Central


### PR DESCRIPTION
Uploading to Central is recoverable — a deployment sits in the portal and can be dropped. **Publishing is not**: that version can never be replaced or removed.

The difference is one plugin flag, and the published parent does not set it — so we would be relying on the plugin's default for an irreversible action. `-DautoPublish=false -DwaitUntil=validated` makes the run upload, validate and stop; going live stays a deliberate click in the portal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)