### PR TITLE
build: add central-publish profile so the Central pass reaches Central

### DIFF
--- a/.github/workflows/CADENZAFLOW_RELEASE.yml
+++ b/.github/workflows/CADENZAFLOW_RELEASE.yml
@@ -402,15 +402,20 @@ jobs:
           # to Nexus (that already happened above).
           # Distro modules are excluded: Central takes libraries, not the
           # Tomcat/Run archives - and javadoc for the whole reactor is heavy.
+          # Two profiles, two jobs:
+          #   sonatype-oss-release - attaches sources, javadoc and signatures
+          #   central-publish      - uploads the signed bundle to Central and
+          #                          switches the Nexus deploy off (see the
+          #                          profile comment in pom.xml). It also pins
+          #                          autoPublish=false / waitUntil=validated,
+          #                          so this uploads and validates but never
+          #                          makes anything public on its own.
           ./mvnw clean deploy \
             --batch-mode --threads 2 \
-            -Psonatype-oss-release \
+            -Psonatype-oss-release,central-publish \
             -Dskip.cadenzaflow.release=true \
             -DskipTests -DskipITs \
             -Dgpg.passphrase="${GPG_PASSPHRASE}" \
-            -Dgpg.args="--pinentry-mode=loopback --batch --yes" \
-            -DautoPublish=false \
-            -DwaitUntil=validated \
             -pl '!qa/integration-tests-engine,!qa/integration-tests-engine-jakarta,!qa/integration-tests-webapps,!qa/test-db-instance-migration,!qa/test-db-rolling-update,!qa/test-old-engine,!qa/large-data-tests,!qa/performance-tests-engine,!qa/tomcat-runtime,!qa/tomcat9-runtime,!qa/wildfly-runtime,!qa/wildfly26-runtime,!distro/tomcat,!distro/run'
 
       - name: Verify the version reached Maven Central

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,12 @@
       See: clirr-maven-plugin usage in parent/pom.xml, commons/pom.xml, engine/pom.xml, etc.
     -->
     <clirr.skip>true</clirr.skip>
+    <!--
+      Deploy to our own Nexus, which is what every ordinary build wants. The
+      central-publish profile switches this off: Maven Central does not take a
+      Maven deploy, it takes a signed bundle uploaded by Sonatype's plugin.
+    -->
+    <cadenzaflow.deploy.skip>false</cadenzaflow.deploy.skip>
   </properties>
 
   <build>
@@ -91,7 +97,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <configuration>
-          <skip>false</skip>
+          <skip>${cadenzaflow.deploy.skip}</skip>
         </configuration>
         <executions>
           <execution>
@@ -101,7 +107,7 @@
               <goal>deploy</goal>
             </goals>
             <configuration>
-              <skip>false</skip>
+              <skip>${cadenzaflow.deploy.skip}</skip>
             </configuration>
           </execution>
         </executions>
@@ -110,6 +116,49 @@
   </build>
 
   <profiles>
+    <!--
+      Publish to Maven Central, in addition to our own Nexus.
+
+      This is the deliberate opt-in the comment above asks for. It has to be a
+      profile because the two destinations need opposite plugin setups:
+
+        Nexus   - maven-deploy-plugin uploads module by module
+        Central - Sonatype's plugin collects the whole reactor into one signed
+                  bundle and uploads that; a plain Maven deploy is rejected
+
+      So the profile turns the extension back ON (it replaces the deploy) and
+      the ordinary deploy OFF. Combine it with -Psonatype-oss-release, which
+      is what attaches the sources, javadoc and GPG signatures Central
+      requires.
+
+      autoPublish stays false and waitUntil stops at "validated" on purpose:
+      the upload is checked but nothing goes public until a human presses
+      Publish in the Central portal. Publishing is irreversible - a version
+      number can never be reused - so that click should stay a human decision.
+    -->
+    <profile>
+      <id>central-publish</id>
+      <properties>
+        <cadenzaflow.deploy.skip>true</cadenzaflow.deploy.skip>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.8.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <skipPublishing>false</skipPublishing>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>false</autoPublish>
+              <waitUntil>validated</waitUntil>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <!-- distro profile is default and builds the complete distribution.
          Does not run integration tests. -->
     <profile>


### PR DESCRIPTION
Follow-up to #35. With gpg signing fixed, trial run [30450358538](https://github.com/cadenzaflow/cadenzaflow-bpm-platform/actions/runs/30450358538) signed everything cleanly and then failed trying to deploy to **Nexus** over a stale raw-IP URL.

That exposed the real gap: **there was no path to Central at all.** The release parent's central-publishing plugin is commented out, and our root POM deliberately keeps the plugin disabled, so `deploy` had only `maven-deploy-plugin` to run.

The two destinations need opposite setups — Nexus takes module-by-module Maven deploys, Central takes one signed bundle from Sonatype's plugin — so this is a profile, exactly as [the comment above the disabled plugin](https://github.com/cadenzaflow/cadenzaflow-bpm-platform/blob/master/pom.xml) asked for:

> when it is set up it should be enabled deliberately, in a profile, not inherited by accident

**Safety:** `autoPublish=false` and `waitUntil=validated` are pinned in the POM rather than passed on the command line. The run uploads and validates; nothing becomes public until a human presses Publish in the portal. Publishing is irreversible, so that stays a human decision.

Verified against the effective POM: extension on, `publish` bound to `deploy`, `maven-deploy-plugin` skipped at both levels.

Also drops `-Dgpg.args`, which never had any effect — `maven-gpg-plugin` is pinned at 1.4, which predates that property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)