### PR TITLE
fix(engine-dmn): materialize FEEL collection results as portable JDK collections

### DIFF
--- a/engine-dmn/feel-scala/src/main/java/org/cadenzaflow/bpm/dmn/feel/impl/scala/ScalaFeelEngine.java
+++ b/engine-dmn/feel-scala/src/main/java/org/cadenzaflow/bpm/dmn/feel/impl/scala/ScalaFeelEngine.java
@@ -37,7 +37,10 @@ import camundajar.impl.scala.util.Either;
 import camundajar.impl.scala.util.Left;
 import camundajar.impl.scala.util.Right;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 
 import static org.camunda.feel.context.VariableProvider.CompositeVariableProvider;
 import static camundajar.impl.scala.jdk.CollectionConverters.ListHasAsScala;
@@ -74,7 +77,7 @@ public class ScalaFeelEngine implements FeelEngine {
     if (either instanceof Right) {
       Right right = (Right) either;
 
-      return (T) right.value();
+      return (T) materializeCollections(right.value());
 
     } else {
       Left left = (Left) either;
@@ -130,6 +133,46 @@ public class ScalaFeelEngine implements FeelEngine {
 
     } else {
       return toScalaList(javaValueMapper);
+
+    }
+  }
+
+  /**
+   * The FEEL engine's {@code JavaValueMapper} unpacks FEEL lists and contexts into thin
+   * Scala-to-Java bridge wrappers ({@code JavaCollectionWrappers$SeqWrapper} and friends,
+   * shaded under {@code camundajar.impl.scala}). They implement the {@code java.util}
+   * interfaces, but their concrete class is engine-internal: once such a value is stored as
+   * a serialized process variable, its {@code objectTypeName} names a class no consumer can
+   * load, and every typed client read fails. Rebuild collection results into portable JDK
+   * collections before they leave the FEEL boundary.
+   */
+  protected Object materializeCollections(Object value) {
+    if (value instanceof java.util.List) {
+      java.util.List<?> list = (java.util.List<?>) value;
+      java.util.List<Object> materialized = new ArrayList<>(list.size());
+      for (Object element : list) {
+        materialized.add(materializeCollections(element));
+      }
+      return materialized;
+
+    } else if (value instanceof java.util.Map) {
+      java.util.Map<?, ?> map = (java.util.Map<?, ?>) value;
+      java.util.Map<Object, Object> materialized = new LinkedHashMap<>();
+      for (java.util.Map.Entry<?, ?> entry : map.entrySet()) {
+        materialized.put(entry.getKey(), materializeCollections(entry.getValue()));
+      }
+      return materialized;
+
+    } else if (value instanceof java.util.Set) {
+      java.util.Set<?> set = (java.util.Set<?>) value;
+      java.util.Set<Object> materialized = new LinkedHashSet<>();
+      for (Object element : set) {
+        materialized.add(materializeCollections(element));
+      }
+      return materialized;
+
+    } else {
+      return value;
 
     }
   }

--- a/engine-dmn/feel-scala/src/test/java/org/cadenzaflow/bpm/dmn/engine/feel/PortableCollectionTypesTest.java
+++ b/engine-dmn/feel-scala/src/test/java/org/cadenzaflow/bpm/dmn/engine/feel/PortableCollectionTypesTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership. Camunda licenses this file to you under the Apache License,
+ * Version 2.0; you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cadenzaflow.bpm.dmn.engine.feel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.cadenzaflow.bpm.dmn.engine.feel.helper.FeelRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * FEEL list and context results must be materialized as portable JDK collections. Without
+ * materialization they surface as shaded Scala bridge wrappers
+ * ({@code camundajar.impl.scala.collection.convert.JavaCollectionWrappers$SeqWrapper} etc.),
+ * and that concrete class ends up as the {@code objectTypeName} of any serialized process
+ * variable holding the result — a class no external consumer can load, so every typed
+ * external-task client read of such a variable fails.
+ */
+public class PortableCollectionTypesTest {
+
+  @Rule
+  public FeelRule feelRule = FeelRule.build();
+
+  @Test
+  public void shouldMaterializeListLiteralAsArrayList() {
+    // when
+    Object result = feelRule.evaluateExpression("[\"email\", \"inbox\"]");
+
+    // then
+    assertThat(result).isExactlyInstanceOf(ArrayList.class);
+    assertThat((List<Object>) result).containsExactly("email", "inbox");
+  }
+
+  @Test
+  public void shouldMaterializeContextLiteralAsLinkedHashMap() {
+    // when
+    Object result = feelRule.evaluateExpression("{channels: [\"email\"], priority: \"high\"}");
+
+    // then
+    assertThat(result).isExactlyInstanceOf(LinkedHashMap.class);
+
+    Map<Object, Object> context = (Map<Object, Object>) result;
+    assertThat(context).containsEntry("priority", "high");
+    assertThat(context.get("channels")).isExactlyInstanceOf(ArrayList.class);
+    assertThat((List<Object>) context.get("channels")).containsExactly("email");
+  }
+
+  @Test
+  public void shouldMaterializeNestedCollectionsDeeply() {
+    // when
+    Object result = feelRule.evaluateExpression(
+        "[{channel: \"email\", tags: [\"a\", \"b\"]}, {channel: \"inbox\", tags: []}]");
+
+    // then
+    assertThat(assertPortable(result)).isTrue();
+
+    List<?> list = (List<?>) result;
+    Map<Object, Object> first = (Map<Object, Object>) list.get(0);
+    assertThat(first).contains(entry("channel", "email"));
+    assertThat((List<Object>) first.get("tags")).containsExactly("a", "b");
+  }
+
+  @Test
+  public void shouldMaterializeListDerivedFromInputVariable() {
+    // given
+    List<String> input = Arrays.asList("email", "inbox", "sms");
+
+    // when
+    Object result = feelRule.evaluateExpression("variable[item != \"sms\"]", input);
+
+    // then
+    assertThat(result).isExactlyInstanceOf(ArrayList.class);
+    assertThat((List<Object>) result).containsExactly("email", "inbox");
+  }
+
+  @Test
+  public void shouldNotWrapScalarResults() {
+    // when
+    Object result = feelRule.evaluateExpression("\"email\"");
+
+    // then
+    assertThat(result).isEqualTo("email");
+  }
+
+  /**
+   * Asserts that every collection in the result tree is a plain JDK class — i.e. loadable by
+   * a consumer that only has the JDK, which is exactly what a typed external-task client
+   * reconstructing {@code objectTypeName} requires.
+   */
+  protected boolean assertPortable(Object value) {
+    if (value instanceof List || value instanceof Map) {
+      assertThat(value.getClass().getName()).startsWith("java.util.");
+    }
+    if (value instanceof List) {
+      for (Object element : (List<?>) value) {
+        assertPortable(element);
+      }
+    } else if (value instanceof Map) {
+      for (Object element : ((Map<?, ?>) value).values()) {
+        assertPortable(element);
+      }
+    }
+    return true;
+  }
+
+}


### PR DESCRIPTION
## Defect

When a DMN decision (or any FEEL expression) returns a list or context, the engine stores the process variable with `objectTypeName` set to the FEEL engine's shaded Scala bridge class (`camundajar.impl.scala.collection.convert.JavaCollectionWrappers$SeqWrapper` / `$MapWrapper`). The JSON value is fine, but that class is engine-internal — no consumer can load it, so every **typed** external-task client read of such a variable fails with `TASK/CLIENT-05002` (`TypeFactory.constructFromCanonical` cannot locate the class). Untyped reads work, which is why the defect stayed latent until the first typed reader (found by Asli in the DNMS e2e gate, 2026-08-17). Inherited from upstream Camunda 7's FEEL-Scala shading; vanilla 7.24 reproduces identically.

**Reproduction:** deploy a DMN whose output entry is a FEEL list literal (`[a,b]`), map the result into a variable, read it with a typed external-task client.

## Fix

`ScalaFeelEngine#evaluateSimpleExpression` now deep-materializes every FEEL result before it leaves the FEEL integration: lists → `java.util.ArrayList`, contexts/maps → `java.util.LinkedHashMap`, sets → `java.util.LinkedHashSet`, recursively; scalars pass through untouched. `objectTypeName` then always records a loadable JDK class, and DMN mappings no longer need per-mapping SPIN normalization (`JSON(x).mapTo(java.util.ArrayList)`) to be safely consumable by typed clients.

One module touched: `engine-dmn/feel-scala`. Consumers (`cadenzaflow-engine-dmn`, `cadenzaflow-engine`, starters/distros) pick the fix up as a normal dependency at the next release.

## Verification (JDK 17)

- New `PortableCollectionTypesTest` fails 4/5 without the fix (asserting the exact `SeqWrapper`/`MapWrapper` leak) and passes 5/5 with it
- `engine-dmn/feel-scala`: 31/31 green
- `engine-dmn/engine`: 388 tests, 0 failures
- `engine` module `test.dmn.**` + `test.api.el.**`: 83/83 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)