### PR TITLE
ci: stop the release tag from starting two competing builds

### DIFF
--- a/.github/workflows/CADENZAFLOW_RELEASE.yml
+++ b/.github/workflows/CADENZAFLOW_RELEASE.yml
@@ -94,7 +94,11 @@ jobs:
         with:
           fetch-depth: 0
           # push: the pushed tag. dispatch: explicit ref, else the version tag.
-          ref: ${{ github.event.inputs.ref || github.event.inputs.version || github.ref }}
+          # `version` is the bare number (1.2.2); the tag carries the
+          # cadenzaflow-v prefix, so it has to be formatted back on. Falling
+          # through to the bare version checked out a ref named "1.2.2", which
+          # does not exist - every dispatch had to pass `ref` by hand.
+          ref: ${{ github.event.inputs.ref || (github.event.inputs.version && format('cadenzaflow-v{0}', github.event.inputs.version)) || github.ref }}
 
       - name: Resolve version & tag
         id: v

--- a/.github/workflows/nexus-deploy.yml
+++ b/.github/workflows/nexus-deploy.yml
@@ -21,9 +21,15 @@ on:
         required: false
         default: ''
         type: string
-  push:
-    tags:
-      - 'cadenzaflow-v*'
+
+# Deliberately NOT triggered by `push: tags: cadenzaflow-v*`.
+# CADENZAFLOW_RELEASE.yml already deploys the same reactor to the same Nexus on
+# a release tag. Wiring this workflow to the tag as well ran two full Maven
+# deploys of identical GAVs at the same moment, on two runner pods of the same
+# scale set - three with the master Test run still in flight. On 2026-08-18
+# (cadenzaflow-v1.2.2) all three pods died within 46 seconds of each other
+# ("The self-hosted runner lost communication with the server") and left 1.2.2
+# half-published on Nexus. This workflow is the ad-hoc deploy: dispatch only.
 
 concurrency:
   group: nexus-deploy-${{ github.ref }}


### PR DESCRIPTION
## What broke

Pushing `cadenzaflow-v1.2.2` started **two** full Maven deploys of the same
reactor to the same Nexus at the same instant — `CADENZAFLOW_RELEASE.yml` and
`nexus-deploy.yml` were both wired to `push: tags: cadenzaflow-v*`. The master
`Test` run from the PR #38 merge, started 19 minutes earlier, was still in
flight. Three heavy jobs, three pods of the `cadenzaflow-runner` scale set:

| Job | started | died | pod |
|---|---|---|---|
| Build & test | 06:31:46 | 07:12:05 | `...-bbn5w` |
| Build, deploy & publish GitHub Release | 06:51:10 | 07:11:19 | `...-7dd6f` |
| Maven deploy to CadenzaFlow Nexus | 06:51:10 | 07:11:24 | `...-dxjhv` |

All three dropped within 46 seconds of each other with *"The self-hosted runner
lost communication with the server"* — a node-level event, not three
independent job failures.

1.2.2 was left half-published on Nexus: **68 of the 142 components** 1.2.1 has,
missing `engine-rest`, `engine-spring-7`, the webapps, every Spring Boot starter
and — the consumer PR #38 exists for — `external-task-client`. No GitHub Release,
no distributions.

## What this changes

1. **`nexus-deploy.yml` no longer fires on release tags.** `CADENZAFLOW_RELEASE.yml`
   already deploys the whole reactor to the same Nexus on a tag; the second
   workflow was duplicated work racing the first over identical GAVs. It keeps
   its `workflow_dispatch` entry point for ad-hoc deploys.

2. **`CADENZAFLOW_RELEASE.yml` rebuilds the tag from `version` on dispatch.**
   The checkout fell through `inputs.ref || inputs.version || github.ref`, so
   leaving `ref` empty checked out a ref named `1.2.2` — which does not exist,
   contradicting the input's own description ("defaults to the version tag").
   Every manual run had to pass `ref` by hand or fail at checkout.

## Recovery already done

1.2.2 was re-driven in two dispatched passes rather than by re-pushing the tag
(a dispatch triggers neither `nexus-deploy` nor `Test`, so nothing competes):

- Pass 1 — `deploy_to_nexus=true`, `build_distros=false` — 12m24s.
  Nexus is now **142/142**, exact parity with 1.2.1.
- Pass 2 — `deploy_to_nexus=false`, `build_distros=true` — 5m27s.
  Release `cadenzaflow-v1.2.2` published with all four distro assets, each
  verified downloadable.

`notify_download` was left off in both passes: the downloads.cadenzaflow.com
publish is a separate call.

## Still open — not fixed here

The scale set will happily place three concurrent Maven builds on one node
again. Removing the duplicate tag trigger takes the release path from three
jobs to two, but the durable fix is on the ARC side — `maxRunners`, or pod
memory requests sized so the node only admits one build at a time. That is
cluster config, not repo config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)