### PR TITLE
ci(security): fail loudly on crashed scans, pre-resolve deps, weekly rescan

### DIFF
--- a/.github/actions/trivy-scan/action.yaml
+++ b/.github/actions/trivy-scan/action.yaml
@@ -20,6 +20,10 @@ inputs:
     description: 'Comma-separated directories to skip'
     required: false
     default: ''
+  fail_on_findings:
+    description: 'Fail the step when vulnerabilities are found (release gate); default only warns'
+    required: false
+    default: 'false'
 
 outputs:
   report_path:
@@ -92,9 +96,13 @@ runs:
         VULN_COUNT=$(cat "$REPORT_PATH" | jq '[.Results[]?.Vulnerabilities // [] | length] | add // 0')
         if [ "$VULN_COUNT" -gt 0 ]; then
           echo "HAS_VULNS=true" >> $GITHUB_OUTPUT
-          echo "::warning::Found $VULN_COUNT vulnerabilities"
           # Print summary per target
           cat "$REPORT_PATH" | jq -r '.Results[]? | select(.Vulnerabilities != null) | "\(.Target): \(.Vulnerabilities | length) vulnerabilities"'
+          if [ "${{ inputs.fail_on_findings }}" = "true" ]; then
+            echo "::error::Found $VULN_COUNT vulnerabilities (severity: ${{ inputs.severity }}) - blocking"
+            exit 2
+          fi
+          echo "::warning::Found $VULN_COUNT vulnerabilities"
         else
           echo "HAS_VULNS=false" >> $GITHUB_OUTPUT
           echo "No vulnerabilities found"

--- a/.github/actions/trivy-scan/action.yaml
+++ b/.github/actions/trivy-scan/action.yaml
@@ -58,7 +58,13 @@ runs:
           SKIP_DIRS_FLAG="--skip-dirs ${{ inputs.skip_dirs }}"
         fi
 
-        # JSON report (single scan - used for PDF and console summary)
+        # JSON report (single scan - used for PDF and console summary).
+        # A crashed Trivy must fail this step: it exits FATAL without writing
+        # the report (seen with Maven Central 429s), and the old `|| true` +
+        # missing-file fallback turned that into the same HAS_VULNS=false a
+        # genuinely clean scan produces - a green 0-finding mail from a scan
+        # that never ran. Findings themselves still only warn, not fail.
+        set +e
         trivy ${{ inputs.scan_type }} \
           --severity ${{ inputs.severity }} \
           --scanners vuln \
@@ -67,22 +73,29 @@ runs:
           $SKIP_DIRS_FLAG \
           --format json \
           --output "$REPORT_PATH" \
-          ${{ inputs.scan_target }} || true
+          ${{ inputs.scan_target }}
+        TRIVY_EXIT=$?
+        set -e
+
+        if [ "$TRIVY_EXIT" -ne 0 ]; then
+          echo "::error::Trivy exited with code $TRIVY_EXIT - failing the scan instead of reporting it as clean"
+          exit "$TRIVY_EXIT"
+        fi
+        if [ ! -f "$REPORT_PATH" ]; then
+          echo "::error::Trivy exited 0 but produced no report at $REPORT_PATH"
+          exit 1
+        fi
 
         echo "REPORT_PATH=$REPORT_PATH" >> $GITHUB_OUTPUT
 
         # Print summary from JSON report
-        if [ -f "$REPORT_PATH" ]; then
-          VULN_COUNT=$(cat "$REPORT_PATH" | jq '[.Results[]?.Vulnerabilities // [] | length] | add // 0')
-          if [ "$VULN_COUNT" -gt 0 ]; then
-            echo "HAS_VULNS=true" >> $GITHUB_OUTPUT
-            echo "::warning::Found $VULN_COUNT vulnerabilities"
-            # Print summary per target
-            cat "$REPORT_PATH" | jq -r '.Results[]? | select(.Vulnerabilities != null) | "\(.Target): \(.Vulnerabilities | length) vulnerabilities"'
-          else
-            echo "HAS_VULNS=false" >> $GITHUB_OUTPUT
-            echo "No vulnerabilities found"
-          fi
+        VULN_COUNT=$(cat "$REPORT_PATH" | jq '[.Results[]?.Vulnerabilities // [] | length] | add // 0')
+        if [ "$VULN_COUNT" -gt 0 ]; then
+          echo "HAS_VULNS=true" >> $GITHUB_OUTPUT
+          echo "::warning::Found $VULN_COUNT vulnerabilities"
+          # Print summary per target
+          cat "$REPORT_PATH" | jq -r '.Results[]? | select(.Vulnerabilities != null) | "\(.Target): \(.Vulnerabilities | length) vulnerabilities"'
         else
           echo "HAS_VULNS=false" >> $GITHUB_OUTPUT
+          echo "No vulnerabilities found"
         fi

--- a/.github/workflows/CADENZAFLOW_RELEASE.yml
+++ b/.github/workflows/CADENZAFLOW_RELEASE.yml
@@ -182,6 +182,25 @@ jobs:
             -DnewVersion="${{ steps.v.outputs.VERSION }}" \
             -DprocessAllModules -DgenerateBackupPoms=false
 
+      - name: Pre-resolve Maven dependencies for the security gate
+        run: |
+          # Trivy resolves pom parent chains itself; on a cold cache that means
+          # unauthenticated requests to Maven Central, whose 429 rate limit
+          # makes Trivy exit FATAL (this silently blinded the push-triggered
+          # scans for two months). Resolving first keeps the gate off remote
+          # repos entirely - and warms the cache for the build step below.
+          ./mvnw -B -q -DskipTests dependency:resolve
+
+      - name: Security gate - no release with known HIGH/CRITICAL findings
+        uses: ./.github/actions/trivy-scan
+        with:
+          scan_type: fs
+          scan_target: .
+          severity: HIGH,CRITICAL
+          output_file: trivy-release-gate.json
+          skip_dirs: .git,node_modules,target,.mvn,docs,test,src/test
+          fail_on_findings: 'true'
+
       - name: Build platform + distros (+ optional Nexus deploy)
         env:
           # settings.xml references ${env.NEXUS_*}, which Maven resolves when IT

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
       - 'cadenzaflow-*.*.*'
+  schedule:
+    # Push-only triggers left the repo unscanned between releases, so CVEs
+    # published in quiet periods never surfaced. Weekly rescan closes that gap.
+    - cron: '0 5 * * 1'
   workflow_dispatch:
 
 env:
@@ -39,6 +43,48 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Detected APP_VERSION: $VERSION"
 
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Cache Maven repository
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.m2/wrapper
+          key: ${{ runner.os }}-maven-scan-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-scan-
+            ${{ runner.os }}-maven-
+
+      - name: Cache Trivy vulnerability DB
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/../.cache/trivy
+          key: trivy-db-${{ github.run_id }}
+          restore-keys: |
+            trivy-db-
+
+      - name: Purge cached CadenzaFlow artifacts (stale parent POMs poison resolution)
+        run: |
+          # See CADENZAFLOW_RELEASE.yml: Maven never re-downloads a RELEASE it
+          # already has, so a parent POM changed after publication survives in
+          # the cache forever. Ours are small - always take them fresh.
+          rm -rf ~/.m2/repository/org/cadenzaflow
+          echo "Purged ~/.m2/repository/org/cadenzaflow"
+
+      - name: Pre-resolve Maven dependencies for Trivy
+        run: |
+          # Trivy resolves pom parent chains and dependency POMs itself; on a
+          # cold runner that meant unauthenticated bursts to Maven Central,
+          # which 429-rate-limits this runner's IP and makes Trivy exit FATAL
+          # before writing a report (every scan since at least 2026-06-29 died
+          # this way). With the local repo populated, Trivy never goes remote.
+          ./mvnw -B -q -DskipTests dependency:resolve
+
       - name: Trivy filesystem scan
         id: trivy_fs
         uses: ./.github/actions/trivy-scan
@@ -50,7 +96,10 @@ jobs:
           skip_dirs: .git,node_modules,target,.mvn,docs,test,src/test
 
       - name: Generate security report and send mail
-        if: always()
+        # No `if: always()` here: when the scan step fails there is no report
+        # file, and the counting fallbacks in security-report turn that into a
+        # green "0 findings" PDF. A failed scan must stay a red workflow, not
+        # become a clean-looking mail.
         uses: ./.github/actions/security-report
         with:
           app_name: ${{ env.APP_NAME }}


### PR DESCRIPTION
## Problem

Every `Security Scan` run since at least 2026-06-29 (first run whose logs still exist) crashed the same way and nobody could see it:

1. Trivy resolves pom parent chains itself. On a cold runner `~/.m2` is empty, so it went straight to Maven Central for `cadenzaflow-bpm-release-parent-1.0.0.pom`.
2. The runner IP is 429-rate-limited by Central (`Retry-After` 191s-1800s across runs), and Trivy treats a 429 as **FATAL** - it exits without writing the report file.
3. `|| true` swallowed the non-zero exit, and the `[ -f "$REPORT_PATH" ]` fallback set `HAS_VULNS=false` - the exact output of a genuinely clean scan.
4. The report step ran under `if: always()`, counted 0/0/0/0 out of the missing file (`jq ... 2>/dev/null || echo "0"`), and mailed a green "0 findings" PDF.

Net effect: the 1.2.1 (Jul 27) and 1.2.2 (Aug 18) release-day pushes were "scanned" by a scanner that had already crashed, and the release pipeline itself had no security step at all. Tomcat 10.1.54 meanwhile accumulated **7 CRITICAL / 4 HIGH** GHSA advisories (fixed in 10.1.55-10.1.57, disclosed from May 11 onward) that never surfaced.

## Changes

**`.github/actions/trivy-scan/action.yaml`**
- Propagate Trivy's exit code: a crashed scan now fails the step with `::error::` instead of impersonating a clean one.
- Fail if Trivy exits 0 without producing a report file.
- New `fail_on_findings` input (default `'false'`): the push-triggered scan keeps warn-only behavior, the release gate below sets it to `'true'`.

**`.github/workflows/security-scan.yml`**
- Pre-populate the local Maven repo before scanning (`./mvnw -B -q -DskipTests dependency:resolve`, per Trivy's own remediation hint) with `actions/cache` on `~/.m2` - Trivy never contacts Central again, killing the 429 at the root.
- Cache the Trivy vulnerability DB (was re-downloading 108 MiB per run).
- Purge cached `org/cadenzaflow` parents before resolving (stale-POM trap, same rationale as nexus-deploy).
- Drop `if: always()` from the report step: a failed scan stays a red workflow instead of becoming a clean-looking mail.
- Add a weekly scheduled run (Mon 05:00 UTC) so CVEs published in quiet periods surface without waiting for a push.

**`.github/workflows/CADENZAFLOW_RELEASE.yml`**
- Blocking security gate between version alignment and the build: pre-resolve dependencies, then Trivy fs scan with `fail_on_findings: 'true'` on HIGH,CRITICAL - a release with known HIGH/CRITICAL findings stops before anything is built or published.

## Expected behavior after merge

The first healthy scan **will report findings** (org.apache.tomcat:tomcat 10.1.54, at minimum the 7 CRITICAL / 4 HIGH above) - the mail to the security team will be red for the first time. That is the fix working, not a regression. The release gate will likewise block any release tagged before the Tomcat bump (#41) lands - intended ordering: merge #41, then tag 1.2.3.

First run on a cold cache still downloads from Central once (Maven, not Trivy); if the IP happens to be inside a 429 window that run fails **visibly** and can simply be re-run.

## Follow-ups (not in this PR)
- Route CI Maven traffic through `nexus.cadenzaflow.com` as a `<mirror>` - `maven-public`/`maven-central` repos exist but need credentialed verification that they proxy Central before wiring in.
- Renovate is not installed on this fork (config + `renovate/*` branches are camunda/camunda-bpm-platform heritage; zero renovate PRs here) - install or replace it so dependency bumps stop being manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)