### PR TITLE
security: bump tomcat 10.1.54 -> 10.1.59, tomcat9 9.0.107 -> 9.0.121

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -76,8 +76,8 @@
     <version.wildfly26>26.1.3.Final</version.wildfly26>
     <version.wildfly26.core>18.1.2.Final</version.wildfly26.core>
 
-    <version.tomcat9>9.0.107</version.tomcat9>
-    <version.tomcat>10.1.54</version.tomcat>
+    <version.tomcat9>9.0.121</version.tomcat9>
+    <version.tomcat>10.1.59</version.tomcat>
 
     <version.arquillian>1.1.10.Final</version.arquillian>
     <version.shrinkwrap.resolvers>2.2.2</version.shrinkwrap.resolvers>


### PR DESCRIPTION
Tomcat 10.1.54 (shipped in the Tomcat distro) carries 26 CVEs fixed in 10.1.55-10.1.59, several rated CRITICAL/HIGH in GHSA/NVD — e.g. CVE-2026-43512 (digest authenticator authenticates any unknown user), CVE-2026-43515 (security constraints not correctly applied), CVE-2026-41293 (HTTP/2 request headers not validated). 10.1.59 (2026-08-13) is the current upstream release; `tomcat9` (QA runtime only) moves to the current 9.0.121 covering the same window.

This is the basis of the **1.2.3 patch release targeted for Monday, 31 Aug** (customer commitment). Merge order with #40 doesn't matter, but both should be on master before the release tag so the first healthy scan and the release gate see 10.1.59, not 10.1.54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)