### PR TITLE
ci(security): scan offline - reactor-internal artifacts sent Trivy remote

### DIFF
--- a/.github/actions/trivy-scan/action.yaml
+++ b/.github/actions/trivy-scan/action.yaml
@@ -68,10 +68,17 @@ runs:
         # missing-file fallback turned that into the same HAS_VULNS=false a
         # genuinely clean scan produces - a green 0-finding mail from a scan
         # that never ran. Findings themselves still only warn, not fail.
+        # --offline-scan: never let Trivy contact remote Maven repos. The
+        # workflows pre-resolve dependencies into ~/.m2, but reactor-internal
+        # artifacts (e.g. cadenzaflow-only-bom) are satisfied from the reactor
+        # and never land there, so Trivy still went to Central for them - and
+        # a 429 there is FATAL. Our own artifacts carry no advisories, so
+        # skipping their remote resolution costs no findings.
         set +e
         trivy ${{ inputs.scan_type }} \
           --severity ${{ inputs.severity }} \
           --scanners vuln \
+          --offline-scan \
           --timeout 30m \
           --cache-dir "$TRIVY_CACHE_DIR" \
           $SKIP_DIRS_FLAG \


### PR DESCRIPTION
Follow-up to #40. The first healthy Security Scan run (33168616879) failed **visibly** - the hardening worked - but exposed one more remote-fetch path: `dependency:resolve` fills `~/.m2` with everything Maven downloads, yet **reactor-internal** artifacts (`org.cadenzaflow.bpm:cadenzaflow-only-bom:1.2.0`) are satisfied from the reactor and never land in the local repo. Trivy went to Central for them and hit the same FATAL 429 (`Retry-After: 1231`) - most likely freshly tripped by the resolve step's own download burst.

Fix: `--offline-scan` on the Trivy command. After pre-resolution Trivy has no legitimate reason to go remote: external parents and dependency POMs are in `~/.m2`, and the only unresolvable artifacts are our own reactor modules, which carry no advisories - skipping them costs no findings. Tomcat detection is unaffected (property chain resolves from the in-repo `parent/pom.xml` plus the pre-resolved external release parents, verified in the May baseline scans).

A 429 is now structurally impossible in the scan step, in both the push-triggered scan and the release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)